### PR TITLE
Fix RSocketWebSocketClient constructor param in docs

### DIFF
--- a/docs/01-client-configuration.md
+++ b/docs/01-client-configuration.md
@@ -29,7 +29,7 @@ const client = new RSocketClient({
     // format of `metadata`
     metadataMimeType: 'application/json', 
   },
-  transport: new RSocketWebSocketClient({uri: 'wss://...'}),
+  transport: new RSocketWebSocketClient({url: 'wss://...'}),
 });
 
 // Open the connection


### PR DESCRIPTION
Fixes typo in docs.  The parameter was shown as `uri` when it should be `url`.