### PR TITLE
Support for RSocketWebSocketClient on nodeJS clients

### DIFF
--- a/packages/rsocket-types/src/ReactiveSocketTypes.js
+++ b/packages/rsocket-types/src/ReactiveSocketTypes.js
@@ -115,7 +115,7 @@ export interface DuplexConnection {
    * Open the underlying connection. Throws if the connection is already in
    * the CLOSED or ERROR state.
    */
-  connect(): void,
+  connect(any): void,
 
   /**
    * Returns a Flowable that immediately publishes the current connection

--- a/packages/rsocket-types/src/ReactiveSocketTypes.js
+++ b/packages/rsocket-types/src/ReactiveSocketTypes.js
@@ -115,7 +115,7 @@ export interface DuplexConnection {
    * Open the underlying connection. Throws if the connection is already in
    * the CLOSED or ERROR state.
    */
-  connect(any): void,
+  connect(): void,
 
   /**
    * Returns a Flowable that immediately publishes the current connection

--- a/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js
+++ b/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js
@@ -36,6 +36,7 @@ export type ClientOptions = {|
  * A WebSocket transport client for use in browser environments.
  */
 export default class RSocketWebSocketClient implements DuplexConnection {
+  _url: string;
   _encoders: ?Encoders<*>;
   _options: ClientOptions;
   _receivers: Set<ISubscriber<Frame>>;
@@ -59,14 +60,14 @@ export default class RSocketWebSocketClient implements DuplexConnection {
     this._close();
   }
 
-  connect(): void {
+  connect(WebSocketCreator: (url: string, options: ClientOptions) => any): void {
     invariant(
       this._status.kind === 'NOT_CONNECTED',
       'RSocketWebSocketClient: Cannot connect(), a connection is already ' +
         'established.',
     );
     this._setConnectionStatus(CONNECTION_STATUS.CONNECTING);
-    const socket = (this._socket = new WebSocket(this._url, this._options);
+    const socket = (this._socket = WebSocketCreator(this._url, this._options));
     socket.binaryType = 'arraybuffer';
 
     (socket.addEventListener: $FlowIssue)('close', this._handleClosed);

--- a/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js
+++ b/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js
@@ -28,7 +28,6 @@ import {
 import {CONNECTION_STATUS} from 'rsocket-types';
 
 export type ClientOptions = {|
-  url: string,
   debug?: boolean,
   lengthPrefixedFrames?: boolean,
 |};
@@ -45,7 +44,8 @@ export default class RSocketWebSocketClient implements DuplexConnection {
   _status: ConnectionStatus;
   _statusSubscribers: Set<ISubject<ConnectionStatus>>;
 
-  constructor(options: ClientOptions, encoders: ?Encoders<*>) {
+  constructor(url: string, options: ClientOptions, encoders: ?Encoders<*>) {
+    this._url = url;
     this._encoders = encoders;
     this._options = options;
     this._receivers = new Set();
@@ -66,7 +66,7 @@ export default class RSocketWebSocketClient implements DuplexConnection {
         'established.',
     );
     this._setConnectionStatus(CONNECTION_STATUS.CONNECTING);
-    const socket = (this._socket = new WebSocket(this._options.url));
+    const socket = (this._socket = new WebSocket(this._url, this._options);
     socket.binaryType = 'arraybuffer';
 
     (socket.addEventListener: $FlowIssue)('close', this._handleClosed);

--- a/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js
+++ b/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js
@@ -50,7 +50,6 @@ export default class RSocketWebSocketClient implements DuplexConnection {
     options: ClientOptions,
     wsCreator: (url: string, options: ClientOptions) => any,
     encoders: ?Encoders<*>) {
-
       this._url = url;
       this._encoders = encoders;
       this._options = options;

--- a/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js
+++ b/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js
@@ -29,8 +29,7 @@ import {CONNECTION_STATUS} from 'rsocket-types';
 
 export type ClientOptions = {|
   url: string,
-  wsOptions?: {},
-  wsCreator?: (url: string, wsOptions?: {}) => WebSocket;
+  wsCreator?: (url: string) => WebSocket;
   debug?: boolean,
   lengthPrefixedFrames?: boolean,
 |};
@@ -48,13 +47,13 @@ export default class RSocketWebSocketClient implements DuplexConnection {
   _statusSubscribers: Set<ISubject<ConnectionStatus>>;
 
   constructor(options: ClientOptions, encoders: ?Encoders<*>) {
-      this._encoders = encoders;
-      this._options = options;
-      this._receivers = new Set();
-      this._senders = new Set();
-      this._socket = null;
-      this._status = CONNECTION_STATUS.NOT_CONNECTED;
-      this._statusSubscribers = new Set();
+    this._encoders = encoders;
+    this._options = options;
+    this._receivers = new Set();
+    this._senders = new Set();
+    this._socket = null;
+    this._status = CONNECTION_STATUS.NOT_CONNECTED;
+    this._statusSubscribers = new Set();
   }
 
   close(): void {
@@ -71,12 +70,7 @@ export default class RSocketWebSocketClient implements DuplexConnection {
 
     const wsCreator = this._options.wsCreator;
     const url = this._options.url;
-    const wsOptions = this._options.wsOptions;
-    if (wsCreator) {
-      this._socket = wsCreator(url, wsOptions);
-    } else {
-      this._socket = new WebSocket(url);
-    }
+    this._socket = wsCreator ? wsCreator(url) : new WebSocket(url);
 
     const socket = this._socket;
     socket.binaryType = 'arraybuffer';


### PR DESCRIPTION
(following facebook internal discussion with @lexs)

RSocketWebSocketClient currently relies on `WebSocket`, which is natively available in browsers. However in nodeJS, there is no native implementation of websockets, so they must be explicitly imported. Attempting to use this client as is in nodeJS throws a "WebSocket not defined" error.

I've updated the `RSocketWebSocketClient` constructor so that it now accepts a function, `wsCreator`, that takes `url` and `options` (similar to the WebSocket constructor), and returns a WebSocket object. This allows the user to pass any websocket constructor they want to RSocketWebSocketClient; for example, a nodeJS client can use [`ws`](https://www.npmjs.com/package/ws).

My change to the `RSocketWebSocketClient` constructor also allows one to pass headers to  `wsCreator`, through the `options` argument. This is a necessary change for some nodeJS clients to work correctly, though it is not currently possible, since the call to the `WebSocket` constructor only extracts `url` from `options`.

I don't have much experience with Flow, so any feedback would be great, particularly on typing things correctly. I'm opening this pull request to get the ball rolling.