### PR TITLE
Make LiteBuffer a proper class and typing

### DIFF
--- a/flow/node.js
+++ b/flow/node.js
@@ -89,7 +89,7 @@ declare class Buffer extends Uint8Array {
   toJSON(): buffer$ToJSONRet;
   toString(encoding?: buffer$Encoding, start?: number, end?: number): string;
   values(): Iterator<number>;
-  write(string: string, offset?: number, length?: number, encoding?: buffer$Encoding): void;
+  write(string: string, offset?: number, length?: number, encoding?: buffer$Encoding): number;
   writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
   writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
   writeFloatBE(value: number, offset: number, noAssert?: boolean): number;

--- a/packages/rsocket-core/src/RSocketSerialization.js
+++ b/packages/rsocket-core/src/RSocketSerialization.js
@@ -16,9 +16,9 @@
  */
 'use strict';
 
-import type {Encodable} from 'rsocket-types';
+import type {Encodable, RSocketBuffer} from 'rsocket-types';
 
-import {LiteBuffer as Buffer} from './LiteBuffer';
+import {isBuffer, toBuffer} from './RSocketBufferUtils';
 import invariant from 'fbjs/lib/invariant';
 
 /**
@@ -43,11 +43,12 @@ export const JsonSerializer: Serializer<*> = {
       return null;
     } else if (typeof data === 'string') {
       str = data;
-    } else if (Buffer.isBuffer(data)) {
-      const buffer: Buffer = data;
+      // FIXME: verify this is called
+    } else if (isBuffer(data)) {
+      const buffer: RSocketBuffer = data;
       str = buffer.toString('utf8');
     } else {
-      const buffer: Buffer = Buffer.from(data);
+      const buffer: RSocketBuffer = toBuffer(data);
       str = buffer.toString('utf8');
     }
     return JSON.parse(str);

--- a/packages/rsocket-core/src/__tests__/LiteBuffer-test.js
+++ b/packages/rsocket-core/src/__tests__/LiteBuffer-test.js
@@ -1,11 +1,10 @@
 'use strict';
-import {Buffer as B} from '../LiteBuffer';
+import LiteBuffer from '../LiteBuffer';
 
-describe('Lite B', () => {
+describe('LiteBuffer', () => {
   it('large values do not improperly roll over', function() {
     const nums = [-25589992, -633756690, -898146932];
-    const out = new B(12);
-    out.fill(0);
+    const out = LiteBuffer.create(12);
     out.writeInt32BE(nums[0], 0);
     let newNum = out.readInt32BE(0);
     expect(nums[0]).toEqual(newNum);
@@ -18,7 +17,7 @@ describe('Lite B', () => {
   });
 
   it('writeUInt32BE and readUInt32BE should work', function() {
-    const buf = B.from([0x12, 0x34, 0x56, 0x78]);
+    const buf = LiteBuffer.from([0x12, 0x34, 0x56, 0x78]);
 
     expect(buf.readUInt32BE(0).toString(16)).toEqual('12345678');
     buf.writeUInt32BE(0x56, 0);
@@ -26,7 +25,7 @@ describe('Lite B', () => {
   });
 
   it('writeUInt8 and readUInt8 should work', function() {
-    const b = new B(3);
+    const b = LiteBuffer.create(3);
     b.writeUInt8(1, 0);
     b.writeUInt8(2, 1);
     b.writeUInt8(3, 2);
@@ -37,7 +36,7 @@ describe('Lite B', () => {
   });
 
   it('writeUInt16BE and readUInt16BE should work', function() {
-    const buf = new B(4);
+    const buf = LiteBuffer.create(4);
 
     buf.writeUInt16BE(0xdead, 0);
     buf.writeUInt16BE(0xbeef, 2);
@@ -47,11 +46,11 @@ describe('Lite B', () => {
   });
 
   it('supports copy, slice and length', function() {
-    const b = new B(3);
+    const b = LiteBuffer.create(3);
     b.writeUInt8(1, 0);
     b.writeUInt8(2, 1);
     b.writeUInt8(3, 2);
-    const buf2 = B(3);
+    const buf2 = LiteBuffer.create(3);
     b.copy(buf2, 0, 1);
     expect(buf2.readUInt8(0)).toEqual(2);
     expect(buf2.readUInt8(1)).toEqual(3);
@@ -60,15 +59,19 @@ describe('Lite B', () => {
     expect(buf2.slice(1, 2).readUInt8(0)).toEqual(3);
   });
 
-  it('supports toString and B.isBuffer', () => {
-    const buf1 = new B(26);
+  it('supports toString', () => {
+    const buf1 = LiteBuffer.create(26);
 
     for (let i = 0; i < 26; i++) {
       // 97 is the decimal ASCII value for 'a'
-      buf1[i] = i + 97;
+      buf1.writeUInt8(i + 97, i);
     }
 
     expect(buf1.toString('utf8')).toEqual('abcdefghijklmnopqrstuvwxyz');
-    expect(B.isBuffer(buf1)).toBe(true);
+  });
+
+  it('from and toString', () => {
+    const buf1 = LiteBuffer.from('hello');
+    expect(buf1.toString('utf8')).toEqual('hello');
   });
 });

--- a/packages/rsocket-core/src/__tests__/RSocketBufferUtils-test.js
+++ b/packages/rsocket-core/src/__tests__/RSocketBufferUtils-test.js
@@ -17,11 +17,26 @@
 
 import {
   byteLength,
+  toArrayLike,
   readUInt24BE,
   readUInt64BE,
   writeUInt24BE,
   writeUInt64BE,
 } from '../RSocketBufferUtils';
+import LiteBuffer from '../LiteBuffer';
+
+function toArray(a: mixed) {
+  if (a.constructor === Uint8Array) return a;
+  if (
+    a.constructor === ArrayBuffer ||
+    a.constructor === Buffer ||
+    a.constructor === Array
+  )
+    return new Uint8Array(a);
+  else {
+    throw new TypeError();
+  }
+}
 
 describe('RSocketBufferUtils', () => {
   describe('byteLength', () => {
@@ -37,6 +52,22 @@ describe('RSocketBufferUtils', () => {
 
     it('returns zero for null', () => {
       expect(byteLength(null, 'utf8')).toBe(0);
+    });
+  });
+
+  describe('toBufferLike', () => {
+    it('to return itself', () => {
+      const buffer = new Buffer('hello');
+      expect(toArrayLike(buffer)).toBe(buffer);
+    });
+
+    it('looks like an ArrayLike', () => {
+      const c = (c: string) => {
+        return c.charCodeAt(0);
+      };
+      const array = Uint8Array.of(c('h'), c('e'), c('l'), c('l'), c('o'));
+      expect(toArray(toArrayLike(new Buffer('hello')))).toEqual(array);
+      expect(toArray(toArrayLike(LiteBuffer.from('hello')))).toEqual(array);
     });
   });
 

--- a/packages/rsocket-core/src/index.js
+++ b/packages/rsocket-core/src/index.js
@@ -74,6 +74,7 @@ export {
   createBuffer,
   readUInt24BE,
   toBuffer,
+  toArrayLike,
   writeUInt24BE,
 } from './RSocketBufferUtils';
 export {

--- a/packages/rsocket-tcp-client/src/RSocketTcpClient.js
+++ b/packages/rsocket-tcp-client/src/RSocketTcpClient.js
@@ -17,12 +17,12 @@
 
 'use strict';
 
+import type {connect as SocketOptions} from 'net';
 import type {ConnectionStatus, DuplexConnection, Frame} from 'rsocket-types';
 import type {ISubject, ISubscriber, ISubscription} from 'rsocket-types';
 import type {Encoders} from 'rsocket-core';
 
 import net from 'net';
-import tls from 'tls';
 import {Flowable} from 'rsocket-flowable';
 import invariant from 'fbjs/lib/invariant';
 import {
@@ -38,14 +38,15 @@ import {CONNECTION_STATUS} from 'rsocket-types';
 export class RSocketTcpConnection implements DuplexConnection {
   _buffer: Buffer;
   _encoders: ?Encoders<*>;
+  _options: SocketOptions;
   _receivers: Set<ISubscriber<Frame>>;
   _senders: Set<ISubscription>;
-  _socket: ?net$Socket;
+  _socket: ?net.Socket;
   _status: ConnectionStatus;
   _statusSubscribers: Set<ISubject<ConnectionStatus>>;
 
-  constructor(socket: ?net$Socket, encoders: ?Encoders<*>) {
-    this._buffer = createBuffer(0);
+  constructor(socket: ?net.Socket, encoders: ?Encoders<*>) {
+    this._buffer = Buffer.alloc(0);
     this._encoders = encoders;
     this._receivers = new Set();
     this._senders = new Set();
@@ -68,7 +69,7 @@ export class RSocketTcpConnection implements DuplexConnection {
     throw new Error('not supported');
   }
 
-  setupSocket(socket: net$Socket) {
+  setupSocket(socket: net.Socket) {
     this._socket = socket;
     socket.on('close', this._handleError);
     socket.on('end', this._handleError);
@@ -181,6 +182,11 @@ export class RSocketTcpConnection implements DuplexConnection {
     // then extract any complete frames plus any remaining data.
     const buffer = Buffer.concat([this._buffer, chunk]);
     const [frames, remaining] = deserializeFrames(buffer, this._encoders);
+    invariant(
+      remaining instanceof Buffer,
+      'Expected value to be a buffer, got `%s`',
+      remaining,
+    );
     this._buffer = remaining;
     return frames;
   }
@@ -203,9 +209,9 @@ export class RSocketTcpConnection implements DuplexConnection {
  * A TCP transport client for use in node environments.
  */
 export class RSocketTcpClient extends RSocketTcpConnection {
-  _options: net$connectOptions;
+  _options: SocketOptions;
 
-  constructor(options: net$connectOptions, encoders: ?Encoders<*>) {
+  constructor(options: SocketOptions, encoders: ?Encoders<*>) {
     super(null, encoders);
     this._options = options;
   }
@@ -214,39 +220,10 @@ export class RSocketTcpClient extends RSocketTcpConnection {
     invariant(
       this.getConnectionState().kind === 'NOT_CONNECTED',
       'RSocketTcpClient: Cannot connect(), a connection is already ' +
-      'established.',
+        'established.',
     );
     this.setConnectionStatus(CONNECTION_STATUS.CONNECTING);
     const socket = net.connect(this._options);
-
-    this.setupSocket(socket);
-    socket.on('connect', this._handleOpened);
-  }
-
-  _handleOpened = (): void => {
-    this.setConnectionStatus(CONNECTION_STATUS.CONNECTED);
-  };
-}
-
-/**
- * A TLS transport client for use in node environments.
- */
-export class RSocketTlsClient extends RSocketTcpConnection {
-  _options: tls$connectOptions;
-
-  constructor(options: tls$connectOptions, encoders: ?Encoders<*>) {
-    super(null, encoders);
-    this._options = options;
-  }
-
-  connect(): void {
-    invariant(
-      this.getConnectionState().kind === 'NOT_CONNECTED',
-      'RSocketTlsClient: Cannot connect(), a connection is already ' +
-      'established.',
-    );
-    this.setConnectionStatus(CONNECTION_STATUS.CONNECTING);
-    const socket = tls.connect(this._options);
 
     this.setupSocket(socket);
     socket.on('connect', this._handleOpened);

--- a/packages/rsocket-types/src/ReactiveSocketTypes.js
+++ b/packages/rsocket-types/src/ReactiveSocketTypes.js
@@ -132,6 +132,50 @@ export interface DuplexConnection {
   connectionStatus(): Flowable<ConnectionStatus>,
 }
 
+export interface RSocketBuffer {
+  +length: number,
+
+  write(
+    input: string,
+    offset: number,
+    length: number,
+    encoding: 'utf8',
+  ): number,
+
+  slice(start: number, end: number): RSocketBuffer,
+
+  readUInt8(offset: number): number,
+
+  readUInt16BE(offset: number): number,
+
+  readUInt32BE(offset: number): number,
+
+  readInt8(offset: number): number,
+
+  readInt16BE(offset: number): number,
+
+  readInt32BE(offset: number): number,
+
+  writeUInt8(value: number, offset: number): number,
+
+  writeUInt16BE(value: number, offset: number): number,
+
+  writeUInt32BE(value: number, offset: number): number,
+
+  writeInt16BE(value: number, offset: number): number,
+
+  writeInt32BE(value: number, offset: number): number,
+
+  toString(encoding?: 'utf8', start?: number, end?: number): string,
+
+  copy(
+    target: self,
+    targetStart?: number,
+    start?: number,
+    end?: number,
+  ): number,
+}
+
 /**
  * Describes the connection status of a ReactiveSocket/DuplexConnection.
  * - NOT_CONNECTED: no connection established or pending.
@@ -158,7 +202,7 @@ export const CONNECTION_STATUS = {
 /**
  * A type that can be written to a buffer.
  */
-export type Encodable = string | Buffer | Uint8Array;
+export type Encodable = string | RSocketBuffer;
 
 /**
  * A single unit of data exchanged between the peers of a `ReactiveSocket`.

--- a/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js
+++ b/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js
@@ -30,6 +30,7 @@ import {
   serializeFrame,
   serializeFrameWithLength,
   toBuffer,
+  toArrayLike,
 } from 'rsocket-core';
 import {CONNECTION_STATUS} from 'rsocket-types';
 
@@ -222,7 +223,7 @@ export default class RSocketWebSocketClient implements DuplexConnection {
         this._socket,
         'RSocketWebSocketClient: Cannot send frame, not connected.',
       );
-      this._socket.send(buffer);
+      this._socket.send(toArrayLike(buffer));
     } catch (error) {
       this._close(error);
     }


### PR DESCRIPTION
Summary:
LiteBuffer today still tries to be a Buffer polyfill, but fails to
provide some methods which makes it not a true polyfill. Instead, stop trying
and make it a separate class, that shared some methods with Buffer. We're
providing utilities to convert from and to Buffer/Uint8array depending on where
you're running.

Differential Revision: D9456672
