### PR TITLE
Support for sending metadata with setupFrame on js client

### DIFF
--- a/packages/rsocket-core/src/RSocketClient.js
+++ b/packages/rsocket-core/src/RSocketClient.js
@@ -39,6 +39,7 @@ export type ClientConfig<D, M> = {|
     dataMimeType: string,
     keepAlive: number,
     lifetime: number,
+    metadata?: string,
     metadataMimeType: string,
   |},
   transport: DuplexConnection,
@@ -169,16 +170,21 @@ class RSocketClientSocket<D, M> implements ReactiveSocket<D, M> {
       dataMimeType,
       keepAlive,
       lifetime,
+      metadata,
       metadataMimeType,
     } = config.setup;
+    let flags = 0;
+    if (metadata !== undefined) {
+      flags |= FLAGS.METADATA;
+    }
     return {
       data: undefined,
       dataMimeType,
-      flags: 0,
+      flags,
       keepAlive,
       lifetime,
       majorVersion: MAJOR_VERSION,
-      metadata: undefined,
+      metadata,
       metadataMimeType,
       minorVersion: MINOR_VERSION,
       resumeToken: null,

--- a/packages/rsocket-core/src/__tests__/RSocketClient-test.js
+++ b/packages/rsocket-core/src/__tests__/RSocketClient-test.js
@@ -78,6 +78,37 @@ describe('RSocketClient', () => {
       });
     });
 
+    it('sends the setup frame with metadata', () => {
+      const transport = genMockConnection();
+      const client = new RSocketClient({
+        setup: {
+          dataMimeType: '<dataMimeType>',
+          keepAlive: 42,
+          lifetime: 2017,
+          metadata: '<metadata>',
+          metadataMimeType: '<metadataMimeType>',
+        },
+        transport,
+      });
+      client.connect().subscribe();
+      transport.mock.connect();
+      expect(transport.sendOne.mock.calls.length).toBe(1);
+      expect(transport.sendOne.mock.frame).toEqual({
+        type: FRAME_TYPES.SETUP,
+        data: undefined,
+        dataMimeType: '<dataMimeType>',
+        flags: 256,
+        keepAlive: 42,
+        lifetime: 2017,
+        metadata: '<metadata>',
+        metadataMimeType: '<metadataMimeType>',
+        resumeToken: null,
+        streamId: 0,
+        majorVersion: 1,
+        minorVersion: 0,
+      });
+    });
+
     it('resolves to a client socket if the transport connects', () => {
       const transport = genMockConnection();
       const client = new RSocketClient({


### PR DESCRIPTION
Now, RSocket had the ability to send metadata with the setupFrame in rsocket-java version. And this PR is for supporting this feature in rsocket-js version. 

PS: We could find the new way that flags calculate [here](https://github.com/rsocket/rsocket-java/blob/102590efb48e9de9359aba984ac8a4dd6f054fb3/rsocket-core/src/main/java/io/rsocket/frame/SetupFrameFlyweight.java#L70) (rsocket-java).