### PR TITLE
Add warning check for browser bug

### DIFF
--- a/packages/rsocket-core/src/RSocketClient.js
+++ b/packages/rsocket-core/src/RSocketClient.js
@@ -127,6 +127,17 @@ class RSocketClientSocket<D, M> implements ReactiveSocket<D, M> {
 
     // Send KEEPALIVE frames
     const {keepAlive} = config.setup;
+    if (
+      keepAlive > 30000 &&
+      navigator &&
+      navigator.userAgent &&
+      (navigator.userAgent.includes('Trident') ||
+        navigator.userAgent.includes('Edg'))
+    ) {
+      console.warn(
+        'rsocket-js: Due to a browser bug, Internet Explorer and Edge users may experience WebSocket instability with keepAlive values longer than 30 seconds.',
+      );
+    }
     const keepAliveFrames = every(keepAlive).map(() => ({
       data: null,
       flags: FLAGS.RESPOND,


### PR DESCRIPTION
Unlike other browsers, when Internet Explorer and Edge experience more than 30 seconds of inactivity on a WebSocket connection, the browsers will start sending the server unsolicited "pong" frames. These unexpected frames can cause issues server-side if not anticipated, potentially overwhelming the server or killing the client connection (Network Error 12030 in both browsers).

Here are a few examples of other people encountering this issue:
https://github.com/http-kit/http-kit/issues/322
https://stackoverflow.com/questions/43811618/microsoft-edge-websocket-error-network-error-12030-using-websockets-after-som
https://stackoverflow.com/questions/32066963/edge-browser-websocket-connection-will-be-automatically-closed-after-an-idle-tim

Since the WebSocket API doesn't allow for controlling this behavior in IE and Edge, the easiest way to sidestep the problem is to set the client keepAlive to 30 seconds or less. This PR provides a warning in the console if the library is loaded in IE or Edge, and the keepAlive value is found to be over 30 seconds. 