### PR TITLE
requestChannel - Can publish >1 payloads

### DIFF
--- a/packages/rsocket-core/src/RSocketMachine.js
+++ b/packages/rsocket-core/src/RSocketMachine.js
@@ -457,7 +457,7 @@ class RSocketMachineImpl<D, M> implements RSocketMachine<D, M> {
                     },
                     onSubscribe: subscription => {
                       this._subscriptions.set(streamId, subscription);
-                      subscription.request(1);
+                      subscription.request(Number.MAX_SAFE_INTEGER);
                     },
                   });
                 } else {


### PR DESCRIPTION
- Right now `subscription.request(1)` causes `requestChannel` to essentially function as a `requestStream` as it only ever requests the initial payload and nothing else.
- Changing 1 -> `MAX_SAFE_INTEGER` allows it to function properly as a `requestChannel` as the requester can publish `MAX_SAFE_INTEGER` number of times.