### PR TITLE
Update link to rsocket.io website in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![Build Status](https://travis-ci.org/rsocket/rsocket-js.svg?branch=master)](https://travis-ci.org/rsocket/rsocket-js)
 
 A JavaScript implementation of the [RSocket](https://github.com/rsocket/rsocket)
-protocol intended for use in browsers and/or Node.js. From [reactivesocket.io](http://reactivesocket.io/):
+protocol intended for use in browsers and/or Node.js. From [rsocket.io/](http://rsocket.io/):
 
-> [RSocket] is an application protocol providing 
-> [Reactive Streams](http://www.reactive-streams.org/) semantics over an 
+> [RSocket] is an application protocol providing
+> [Reactive Streams](http://www.reactive-streams.org/) semantics over an
 > asynchronous, binary boundary.
 >
-> It enables the following symmetric interaction models via async message 
+> It enables the following symmetric interaction models via async message
 > passing over a single connection:
 >
 > - request/response (stream of 1)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/rsocket/rsocket-js.svg?branch=master)](https://travis-ci.org/rsocket/rsocket-js)
 
 A JavaScript implementation of the [RSocket](https://github.com/rsocket/rsocket)
-protocol intended for use in browsers and/or Node.js. From [rsocket.io/](http://rsocket.io/):
+protocol intended for use in browsers and/or Node.js. From [rsocket.io](http://rsocket.io/):
 
 > [RSocket] is an application protocol providing
 > [Reactive Streams](http://www.reactive-streams.org/) semantics over an

--- a/docs/00-index.md
+++ b/docs/00-index.md
@@ -1,7 +1,7 @@
 # rsocket-js
 
 `rsocket-js` implements the 1.0 version of the [RSocket protocol](https://github.com/rsocket/rsocket)
-and is designed for use in Node.js and browsers. From [reactivesocket.io](http://reactivesocket.io/):
+and is designed for use in Node.js and browsers. From [rsocket.io](http://rsocket.io/):
 
 > ReactiveSocket is an application protocol providing Reactive Streams semantics
 > over an asynchronous, binary boundary.
@@ -15,7 +15,7 @@ there may be bugs):
 - Node.js TCP transport client
 - Browser WebSocket client (binary)
 - TCK client for spec compliance testing
-- UTF-8 and Binary encoding at the transport layer 
+- UTF-8 and Binary encoding at the transport layer
 - Optional JSON (de)serialization at the rsocket layer (send and receive objects
   instead of strings)
 - ReactiveStream data types
@@ -25,12 +25,12 @@ The following features are not yet implemented:
 - `requestChannel()`
 - `metadataPush()`
 - rsocket server
-- LEASE 
-- RESUME 
+- LEASE
+- RESUME
 
 ## Reactive Streams
 
-rsocket-js includes an implementation of the [Reactive Streams](http://www.reactive-streams.org/) 
+rsocket-js includes an implementation of the [Reactive Streams](http://www.reactive-streams.org/)
 API in JavaScript. Note that unlike standard Rx Observables, Reactive Streams are
 *lazy*, *pull-based*, and support *back-pressure*. Two types are implemented:
 


### PR DESCRIPTION
Updates the link to the main rsocket documentation site in `README.md`.