### PR TITLE
Add missing package declaration

### DIFF
--- a/packages/rsocket-tcp-client/package.json
+++ b/packages/rsocket-tcp-client/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "fbjs": "^1.0.0",
     "rsocket-core": "^0.0.16",
-    "rsocket-flowable": "^0.0.14"
+    "rsocket-flowable": "^0.0.14",
+    "rsocket-types": "^0.0.16"
   }
 }


### PR DESCRIPTION
inside rsocket-tcp-client, the `rsocket-types` is used by this [code](https://github.com/rsocket/rsocket-js/blob/master/packages/rsocket-tcp-client/src/RSocketTcpClient.js#L20), but there is no declaration in it's `package.json`.