### PR TITLE
fixes the failure in case of running the RSocketClient in node env

### DIFF
--- a/packages/rsocket-core/src/RSocketClient.js
+++ b/packages/rsocket-core/src/RSocketClient.js
@@ -116,6 +116,8 @@ export default class RSocketClient<D, M> {
   _checkConfig(config: ClientConfig<D, M>) {
     const setup = config.setup;
     const keepAlive = setup && setup.keepAlive;
+    // wrap in try catch since in 'strict' mode the access to an unexciting window will throw
+    // the ReferenceError: window is not defined exception
     try {
       const navigator = window && window.navigator;
       if (
@@ -129,7 +131,9 @@ export default class RSocketClient<D, M> {
           'rsocket-js: Due to a browser bug, Internet Explorer and Edge users may experience WebSocket instability with keepAlive values longer than 30 seconds.',
         );
       }
-    } catch (e) {}
+    } catch (e) {
+      // ignore the error since it means that the code is running in non browser environment
+    }
   }
 }
 

--- a/packages/rsocket-core/src/RSocketClient.js
+++ b/packages/rsocket-core/src/RSocketClient.js
@@ -114,20 +114,22 @@ export default class RSocketClient<D, M> {
   }
 
   _checkConfig(config: ClientConfig<D, M>) {
-    const navigator = window && window.navigator;
     const setup = config.setup;
     const keepAlive = setup && setup.keepAlive;
-    if (
-      keepAlive > 30000 &&
-      navigator &&
-      navigator.userAgent &&
-      (navigator.userAgent.includes('Trident') ||
-        navigator.userAgent.includes('Edg'))
-    ) {
-      console.warn(
-        'rsocket-js: Due to a browser bug, Internet Explorer and Edge users may experience WebSocket instability with keepAlive values longer than 30 seconds.',
-      );
-    }
+    try {
+      const navigator = window && window.navigator;
+      if (
+        keepAlive > 30000 &&
+        navigator &&
+        navigator.userAgent &&
+        (navigator.userAgent.includes('Trident') ||
+          navigator.userAgent.includes('Edg'))
+      ) {
+        console.warn(
+          'rsocket-js: Due to a browser bug, Internet Explorer and Edge users may experience WebSocket instability with keepAlive values longer than 30 seconds.',
+        );
+      }
+    } catch (e) {}
   }
 }
 


### PR DESCRIPTION
This PR provides a fix to the access to `window` variable within the node env in strict mode
which led to failure