### PR TITLE
makes Single.error() return a Single<empty>

### DIFF
--- a/packages/rsocket-flowable/src/Single.js
+++ b/packages/rsocket-flowable/src/Single.js
@@ -82,7 +82,7 @@ export default class Single<T> {
     });
   }
 
-  static error<U = never>(error: Error): Single<U> {
+  static error<U = empty>(error: Error): Single<U> {
     return new Single(subscriber => {
       subscriber.onSubscribe();
       subscriber.onError(error);

--- a/packages/rsocket-flowable/src/Single.js
+++ b/packages/rsocket-flowable/src/Single.js
@@ -82,7 +82,7 @@ export default class Single<T> {
     });
   }
 
-  static error<U>(error: Error): Single<U> {
+  static error(error: Error): Single<never> {
     return new Single(subscriber => {
       subscriber.onSubscribe();
       subscriber.onError(error);

--- a/packages/rsocket-flowable/src/Single.js
+++ b/packages/rsocket-flowable/src/Single.js
@@ -82,7 +82,7 @@ export default class Single<T> {
     });
   }
 
-  static error(error: Error): Single<never> {
+  static error<U = never>(error: Error): Single<U> {
     return new Single(subscriber => {
       subscriber.onSubscribe();
       subscriber.onError(error);


### PR DESCRIPTION
A `Single` produced by `Single.error()` should be assignable to any `Single<T>` type.
```ts
const willAlwaysError = Single.error(new Error());
const mySingle: Single<Foo> = willAlwaysError; // <-- this should always typecheck
```

This PR changes the default value of `Single.error`'s type param to be `never`, making it assignable to any `Single<T>` type.

This is the direct analogy of the default of `never` (same as `empty`) in TypeScript's [`Promise.reject`](https://github.com/microsoft/TypeScript/blob/c6cdc63b9c8d557dfa8ff0069972dc238292bb4e/lib/lib.es2015.promise.d.ts#L136):
```ts
reject<T = never>(reason?: any): Promise<T>;
```