### PR TITLE
makes Flowable.error() and Flowable.never() return a Flowable<empty>

### DIFF
--- a/packages/rsocket-flowable/src/Flowable.js
+++ b/packages/rsocket-flowable/src/Flowable.js
@@ -61,7 +61,7 @@ export default class Flowable<T> implements IPublisher<T> {
     });
   }
 
-  static error<U>(error: Error): Flowable<U> {
+  static error<U = empty>(error: Error): Flowable<U> {
     return new Flowable(subscriber => {
       subscriber.onSubscribe({
         cancel: () => {},
@@ -72,7 +72,7 @@ export default class Flowable<T> implements IPublisher<T> {
     });
   }
 
-  static never<U>(): Flowable<U> {
+  static never<U = empty>(): Flowable<U> {
     return new Flowable(subscriber => {
       subscriber.onSubscribe({
         cancel: emptyFunction,


### PR DESCRIPTION
Same as #76, but this time for `Flowable`.

DefinitelyTyped PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43318