### PR TITLE
adds Single.never()

### DIFF
--- a/packages/rsocket-flowable/src/Single.js
+++ b/packages/rsocket-flowable/src/Single.js
@@ -89,6 +89,12 @@ export default class Single<T> {
     });
   }
 
+  static never<U = empty>(): Single<U> {
+    return new Single(subscriber => {
+      subscriber.onSubscribe();
+    });
+  }
+
   constructor(source: Source<T>) {
     this._source = source;
   }


### PR DESCRIPTION
This PR adds `Single.never()`, analogous to `Flowable.never()`:
https://github.com/rsocket/rsocket-js/blob/bb11e451d50ef5520580611661627aa14ee1a3f0/packages/rsocket-flowable/src/Flowable.js#L75-L82