### PR TITLE
Provides Auth Metadata and Routing Metadata Support

### DIFF
--- a/packages/rsocket-core/src/AuthMetadata.js
+++ b/packages/rsocket-core/src/AuthMetadata.js
@@ -1,0 +1,226 @@
+// @flow
+
+import {LiteBuffer as Buffer} from './LiteBuffer';
+import {createBuffer, toBuffer} from './RSocketBufferUtils';
+import WellKnownAuthType, {
+  UNPARSEABLE_AUTH_TYPE,
+  UNKNOWN_RESERVED_AUTH_TYPE,
+  SIMPLE,
+  BEARER,
+} from './WellKnownAuthType';
+
+const authTypeIdBytesLength = 1;
+const customAuthTypeBytesLength = 1;
+const usernameLengthBytesLength = 2;
+
+const streamMetadataKnownMask = 0x80; // 1000 0000
+const streamMetadataLengthMask = 0x7f; // 0111 1111
+
+type AuthMetadata = {|
+  type: {|
+    identifier: number,
+    string: string,
+  |},
+  payload: Buffer,
+|};
+
+type UsernameAndPassword = {| username: Buffer, password: Buffer |};
+
+/**
+ * Encode Auth metadata with the given {@link WellKnownAuthType} and auth payload {@link Buffer}
+ *
+ * @param authType well known auth type
+ * @param authPayloadBuffer auth payload buffer
+ * @returns encoded {@link WellKnownAuthType} and payload {@link Buffer}
+ */
+export function encodeWellKnownAuthMetadata(
+  authType: WellKnownAuthType,
+  authPayloadBuffer: Buffer
+): Buffer {
+  if (
+    authType === UNPARSEABLE_AUTH_TYPE ||
+    authType === UNKNOWN_RESERVED_AUTH_TYPE
+  ) {
+    throw new Error(
+      `Illegal WellKnownAuthType[${authType.toString()}]. Only allowed AuthType should be used`
+    );
+  }
+
+  const buffer = createBuffer(authTypeIdBytesLength);
+
+  // eslint-disable-next-line no-bitwise
+  buffer.writeUInt8(authType.identifier | streamMetadataKnownMask);
+
+  return Buffer.concat([buffer, authPayloadBuffer]);
+}
+
+/**
+ * Encode Auth metadata with the given custom auth type {@link string} and auth payload {@link Buffer}
+ *
+ * @param customAuthType custom auth type
+ * @param authPayloadBuffer auth payload buffer
+ * @returns encoded {@link WellKnownAuthType} and payload {@link Buffer}
+ */
+export function encodeCustomAuthMetadata(
+  customAuthType: string,
+  authPayloadBuffer: Buffer
+): Buffer {
+  const customAuthTypeBuffer = toBuffer(customAuthType);
+
+  if (customAuthTypeBuffer.byteLength !== customAuthType.length) {
+    throw new Error('Custom auth type must be US_ASCII characters only');
+  }
+  if (
+    customAuthTypeBuffer.byteLength < 1 ||
+    customAuthTypeBuffer.byteLength > 128
+  ) {
+    throw new Error(
+      'Custom auth type must have a strictly positive length that fits on 7 unsigned bits, ie 1-128'
+    );
+  }
+
+  const buffer = createBuffer(
+    customAuthTypeBytesLength + customAuthTypeBuffer.byteLength
+  );
+
+  // encoded length is one less than actual length, since 0 is never a valid length, which gives
+  // wider representation range
+  buffer.writeUInt8(customAuthTypeBuffer.byteLength - 1);
+  buffer.write(customAuthType, customAuthTypeBytesLength);
+
+  return Buffer.concat([buffer, authPayloadBuffer]);
+}
+
+/**
+ * Encode Simple Auth metadata with the given username and password
+ *
+ * @param username username
+ * @param password password
+ * @returns encoded {@link SIMPLE} and given username and password as auth payload {@link Buffer}
+ */
+export function encodeSimpleAuthMetadata(
+  username: string | Buffer,
+  password: string | Buffer
+): Buffer {
+  const usernameBuffer = toBuffer(username);
+  const passwordBuffer = toBuffer(password);
+  const usernameLength = usernameBuffer.byteLength;
+
+  if (usernameLength > 65535) {
+    throw new Error(
+      `Username should be shorter than or equal to 65535 bytes length in UTF-8 encoding but the given was ${usernameLength}`
+    );
+  }
+
+  const capacity = authTypeIdBytesLength + usernameLengthBytesLength;
+  const buffer = createBuffer(capacity);
+
+  // eslint-disable-next-line no-bitwise
+  buffer.writeUInt8(SIMPLE.identifier | streamMetadataKnownMask);
+  buffer.writeUInt16BE(usernameLength, 1);
+
+  return Buffer.concat([buffer, usernameBuffer, passwordBuffer]);
+}
+
+/**
+ * Encode Bearer Auth metadata with the given token
+ *
+ * @param token token
+ * @returns encoded {@link BEARER} and given token as auth payload {@link Buffer}
+ */
+export function encodeBearerAuthMetadata(token: string | Buffer): Buffer {
+  const tokenBuffer = toBuffer(token);
+  const buffer = createBuffer(authTypeIdBytesLength);
+
+  // eslint-disable-next-line no-bitwise
+  buffer.writeUInt8(BEARER.identifier | streamMetadataKnownMask);
+
+  return Buffer.concat([buffer, tokenBuffer]);
+}
+
+/**
+ * Decode auth metadata {@link Buffer} into {@link AuthMetadata} object
+ *
+ * @param metadata auth metadata {@link Buffer}
+ * @returns decoded {@link AuthMetadata}
+ */
+export function decodeAuthMetadata(metadata: Buffer): AuthMetadata {
+  if (metadata.byteLength < 1) {
+    throw new Error(
+      'Unable to decode Auth metadata. Not enough readable bytes'
+    );
+  }
+
+  const lengthOrId = metadata.readUInt8();
+  // eslint-disable-next-line no-bitwise
+  const normalizedId = lengthOrId & streamMetadataLengthMask;
+
+  if (normalizedId !== lengthOrId) {
+    const authType = WellKnownAuthType.fromIdentifier(normalizedId);
+
+    return {
+      payload: metadata.slice(1),
+      type: {
+        identifier: authType.identifier,
+        string: authType.string,
+      },
+    };
+  } else {
+    // encoded length is realLength - 1 in order to avoid intersection with 0x00 authtype
+    const realLength = lengthOrId + 1;
+    if (metadata.byteLength < realLength + customAuthTypeBytesLength) {
+      throw new Error(
+        'Unable to decode custom Auth type. Malformed length or auth type string'
+      );
+    }
+
+    const customAuthTypeString = metadata.toString(
+      'utf8',
+      customAuthTypeBytesLength,
+      customAuthTypeBytesLength + realLength
+    );
+    const payload = metadata.slice(realLength + customAuthTypeBytesLength);
+
+    return {
+      payload,
+      type: {
+        identifier: UNPARSEABLE_AUTH_TYPE.identifier,
+        string: customAuthTypeString,
+      },
+    };
+  }
+}
+
+/**
+ * Read up to 129 bytes from the given metadata in order to get the custom Auth Type
+ *
+ * @param authPayload
+ * @return sliced username and password buffers
+ */
+export function decodeSimpleAuthPayload(
+  authPayload: Buffer
+): UsernameAndPassword {
+  if (authPayload.byteLength < usernameLengthBytesLength) {
+    throw new Error(
+      'Unable to decode Simple Auth Payload. Not enough readable bytes'
+    );
+  }
+
+  const usernameLength = authPayload.readUInt16BE();
+
+  if (authPayload.byteLength < usernameLength + usernameLengthBytesLength) {
+    throw new Error(
+      'Unable to decode Simple Auth Payload. Not enough readable bytes'
+    );
+  }
+
+  const username = authPayload.slice(
+    usernameLengthBytesLength,
+    usernameLengthBytesLength + usernameLength
+  );
+  const password = authPayload.slice(
+    usernameLengthBytesLength + usernameLength
+  );
+
+  return {password, username};
+}

--- a/packages/rsocket-core/src/LiteBuffer.js
+++ b/packages/rsocket-core/src/LiteBuffer.js
@@ -570,7 +570,8 @@ export class Buffer extends Uint8Array {
         ? byteOffsetOrEncoding
         : undefined;
 
-    if (typeof value == 'string') {
+    if (typeof value === 'string' || value.constructor.name === 'String') {
+      value = value.toString();
       encoding = checkEncoding(encoding, false);
       // if (encoding === 'hex') {return new Buffer(hex.decodeString(value).buffer);}
       // if (encoding === 'base64') {return new Buffer(base64.decode(value));}

--- a/packages/rsocket-core/src/LiteBuffer.js
+++ b/packages/rsocket-core/src/LiteBuffer.js
@@ -318,7 +318,7 @@ function utf8ToBytes(str: string, pUnits: number = Infinity): number[] {
   return bytes;
 }
 
-function utf8Slice(buf, start, end) {
+function utf8Slice(buf: Buffer, start: number, end: number) {
   end = Math.min(buf.length, end);
   const res = [];
 

--- a/packages/rsocket-core/src/RSocketBufferUtils.js
+++ b/packages/rsocket-core/src/RSocketBufferUtils.js
@@ -20,7 +20,6 @@
 /* eslint-disable no-bitwise */
 
 import {LiteBuffer as Buffer} from './LiteBuffer';
-import invariant from 'fbjs/lib/invariant';
 
 export type Encoding = 'ascii' | 'base64' | 'hex' | 'utf8';
 
@@ -92,24 +91,27 @@ export function byteLength(data: any, encoding: Encoding): number {
 /**
  * Attempts to construct a buffer from the input, throws if invalid.
  */
-export function toBuffer(data: mixed): Buffer {
-  // Buffer.from(buffer) copies which we don't want here
-  if (data instanceof Buffer) {
-    return data;
-  }
-  invariant(
-    data instanceof ArrayBuffer,
-    'RSocketBufferUtils: Cannot construct buffer. Expected data to be an ' +
-      'arraybuffer, got `%s`.',
-    data,
-  );
-  return Buffer.from(data);
-}
+export const toBuffer: (...args: any[]) => Buffer =
+  typeof Buffer.from === 'function'
+    ? (...args: any[]) => {
+        // Buffer.from(buffer) copies which we don't want here
+        if (args[0] instanceof Buffer) {
+          return args[0];
+        }
+        return Buffer.from.apply(Buffer, args);
+      }
+    : (...args: any[]) => {
+        // Buffer.from(buffer) copies which we don't want here
+        if (args[0] instanceof Buffer) {
+          return args[0];
+        }
+        return new (Buffer.bind.apply(Buffer, [Buffer, ...args]))();
+      };
+
 
 /**
  * Function to create a buffer of a given sized filled with zeros.
  */
-
 export const createBuffer: (...args: any[]) => Buffer =
   typeof Buffer.alloc === 'function'
     ? (length: number) => Buffer.alloc(length)

--- a/packages/rsocket-core/src/RoutingMetadata.js
+++ b/packages/rsocket-core/src/RoutingMetadata.js
@@ -1,0 +1,60 @@
+// $FlowFixMe
+// @flow
+
+import {LiteBuffer as Buffer} from './LiteBuffer';
+import {createBuffer, toBuffer} from './RSocketBufferUtils';
+
+/**
+ * Encode given set of routes into {@link Buffer} following the <a href="https://github.com/rsocket/rsocket/blob/master/Extensions/Routing.md">Routing Metadata Layout</a>
+ *
+ * @param routes non-empty set of routes
+ * @returns {Buffer} with encoded content
+ */
+export function encodeRoutes(...routes: string[]): Buffer {
+  if (routes.length < 1) {
+    throw new Error('routes should be non empty array');
+  }
+
+  return Buffer.concat(routes.map(route => encodeRoute(route)));
+}
+
+export function encodeRoute(route: string): Buffer {
+  const encodedRoute = toBuffer(route, 'utf8');
+
+  if (encodedRoute.length > 255) {
+    throw new Error(
+      `route length should fit into unsigned byte length but the given one is ${encodedRoute.length}`
+    );
+  }
+
+  const encodedLength = createBuffer(1);
+
+  encodedLength.writeUInt8(encodedRoute.length);
+
+  return Buffer.concat([encodedLength, encodedRoute]);
+}
+
+export function* decodeRoutes(
+  routeMetadataBuffer: Buffer
+): Generator<string, void, any> {
+  const length = routeMetadataBuffer.byteLength;
+  let offset = 0;
+
+  while (offset < length) {
+    const routeLength = routeMetadataBuffer.readUInt8(offset++);
+
+    if (offset + routeLength > length) {
+      throw new Error(
+        `Malformed RouteMetadata. Offset(${offset}) + RouteLength(${routeLength}) is greater than TotalLength`
+      );
+    }
+
+    const route = routeMetadataBuffer.toString(
+      'utf8',
+      offset,
+      offset + routeLength
+    );
+    offset += routeLength;
+    yield route;
+  }
+}

--- a/packages/rsocket-core/src/WellKnownAuthType.js
+++ b/packages/rsocket-core/src/WellKnownAuthType.js
@@ -1,0 +1,108 @@
+'use strict';
+// @flow
+
+export default class WellKnownAuthType {
+  _identifier: number;
+  _string: string;
+
+  constructor(str: string, identifier: number) {
+    this._string = str;
+    this._identifier = identifier;
+  }
+
+  /**
+   * Find the {@link WellKnownAuthType} for the given identifier (as an {@link number}). Valid
+   * identifiers are defined to be integers between 0 and 127, inclusive. Identifiers outside of
+   * this range will produce the {@link #UNPARSEABLE_AUTH_TYPE}. Additionally, some identifiers in
+   * that range are still only reserved and don't have a type associated yet: this method returns
+   * the {@link #UNKNOWN_RESERVED_AUTH_TYPE} when passing such an identifier, which lets call sites
+   * potentially detect this and keep the original representation when transmitting the associated
+   * metadata buffer.
+   *
+   * @param id the looked up identifier
+   * @return the {@link WellKnownAuthType}, or {@link #UNKNOWN_RESERVED_AUTH_TYPE} if the id is out
+   *     of the specification's range, or {@link #UNKNOWN_RESERVED_AUTH_TYPE} if the id is one that
+   *     is merely reserved but unknown to this implementation.
+   */
+  static fromIdentifier(id: number): WellKnownAuthType {
+    if (id < 0x00 || id > 0x7f) {
+      return UNPARSEABLE_AUTH_TYPE;
+    }
+    return TYPES_BY_AUTH_ID[id];
+  }
+
+  /**
+   * Find the {@link WellKnownAuthType} for the given {@link String} representation. If the
+   * representation is {@code null} or doesn't match a {@link WellKnownAuthType}, the {@link
+   * #UNPARSEABLE_AUTH_TYPE} is returned.
+   *
+   * @param authTypeString the looked up mime type
+   * @return the matching {@link WellKnownAuthType}, or {@link #UNPARSEABLE_AUTH_TYPE} if none
+   *     matches
+   */
+  static fromString(authTypeString: string): WellKnownAuthType {
+    if (!authTypeString) {
+      throw new Error('type must be non-null');
+    }
+
+    // force UNPARSEABLE if by chance UNKNOWN_RESERVED_MIME_TYPE's text has been used
+    if (authTypeString === UNKNOWN_RESERVED_AUTH_TYPE.string) {
+      return UNPARSEABLE_AUTH_TYPE;
+    }
+
+    return TYPES_BY_AUTH_STRING.get(authTypeString) || UNPARSEABLE_AUTH_TYPE;
+  }
+
+  /** @return the byte identifier of the mime type, guaranteed to be positive or zero. */
+  get identifier(): number {
+    return this._identifier;
+  }
+
+  /**
+   * @return the mime type represented as a {@link String}, which is made of US_ASCII compatible
+   *     characters only
+   */
+  get string(): string {
+    return this._string;
+  }
+
+  /** @see #string() */
+  toString(): string {
+    return this._string;
+  }
+}
+
+export const UNPARSEABLE_AUTH_TYPE: WellKnownAuthType = new WellKnownAuthType(
+  'UNPARSEABLE_AUTH_TYPE_DO_NOT_USE',
+  -2
+);
+export const UNKNOWN_RESERVED_AUTH_TYPE: WellKnownAuthType = new WellKnownAuthType(
+  'UNKNOWN_YET_RESERVED_DO_NOT_USE',
+  -1
+);
+
+export const SIMPLE: WellKnownAuthType = new WellKnownAuthType('simple', 0x00);
+export const BEARER: WellKnownAuthType = new WellKnownAuthType('bearer', 0x01);
+
+export const TYPES_BY_AUTH_ID: WellKnownAuthType[] = new Array(128);
+export const TYPES_BY_AUTH_STRING: Map<string, WellKnownAuthType> = new Map();
+
+const ALL_MIME_TYPES: WellKnownAuthType[] = [
+  UNPARSEABLE_AUTH_TYPE,
+  UNKNOWN_RESERVED_AUTH_TYPE,
+  SIMPLE,
+  BEARER,
+];
+
+TYPES_BY_AUTH_ID.fill(UNKNOWN_RESERVED_AUTH_TYPE);
+
+for (const value of ALL_MIME_TYPES) {
+  if (value.identifier >= 0) {
+    TYPES_BY_AUTH_ID[value.identifier] = value;
+    TYPES_BY_AUTH_STRING.set(value.string, value);
+  }
+}
+
+if (Object.seal) {
+  Object.seal(TYPES_BY_AUTH_ID);
+}

--- a/packages/rsocket-core/src/__tests__/AuthMetadata-test.js
+++ b/packages/rsocket-core/src/__tests__/AuthMetadata-test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+import {
+  decodeAuthMetadata,
+  decodeSimpleAuthPayload,
+  encodeCustomAuthMetadata,
+  encodeSimpleAuthMetadata,
+  encodeWellKnownAuthMetadata,
+} from '../AuthMetadata';
+import {
+  SIMPLE,
+  UNKNOWN_RESERVED_AUTH_TYPE,
+  UNPARSEABLE_AUTH_TYPE,
+} from '../WellKnownAuthType';
+
+describe('Auth Metadata', () => {
+  it('should encode Custom Auth Metadata', () => {
+    const customAuthType = 'custom/auth/type';
+    const customAuthMetadata = encodeCustomAuthMetadata(
+      customAuthType,
+      Buffer.from([220, 1])
+    );
+
+    expect(customAuthMetadata).toEqual(
+      Buffer.concat([
+        Buffer.from([customAuthType.length - 1]),
+        Buffer.from(customAuthType),
+        Buffer.from([220, 1]),
+      ])
+    );
+  });
+
+  it('should error encoding too long Custom Auth Metadata', () => {
+    let customAuthType = '';
+
+    for (let i = 0; i < 129; i++) {
+      customAuthType += '1';
+    }
+
+    expect(() =>
+      encodeCustomAuthMetadata(customAuthType, Buffer.from([220, 1]))
+    ).toThrow(
+      'Custom auth type must have a strictly positive length that fits on 7 unsigned bits, ie 1-128'
+    );
+  });
+
+  it('should error encoding on empty Custom Auth Metadata', () => {
+    const customAuthType = '';
+
+    expect(() =>
+      encodeCustomAuthMetadata(customAuthType, Buffer.from([220, 1]))
+    ).toThrow(
+      'Custom auth type must have a strictly positive length that fits on 7 unsigned bits, ie 1-128'
+    );
+  });
+
+  it('should error encoding on non ASCII Custom Auth Metadata', () => {
+    const customAuthType = 'asdasd🃓𝑓';
+
+    expect(() =>
+      encodeCustomAuthMetadata(customAuthType, Buffer.from([220, 1]))
+    ).toThrow('Custom auth type must be US_ASCII characters only');
+  });
+
+  it('should encode WellKnown Auth Metadata', () => {
+    const wellKnownAuthMetadata = encodeWellKnownAuthMetadata(
+      SIMPLE,
+      Buffer.from([1, 1, 1, 1])
+    );
+
+    expect(wellKnownAuthMetadata).toEqual(
+      Buffer.concat([
+        // eslint-disable-next-line no-bitwise
+        Buffer.from([SIMPLE.identifier | 0x80]),
+        Buffer.from([1, 1, 1, 1]),
+      ])
+    );
+  });
+
+  it('should error on UNKNOWN or UNPARSEABLE WellKnownAuthType', () => {
+    expect(() =>
+      encodeWellKnownAuthMetadata(
+        UNKNOWN_RESERVED_AUTH_TYPE,
+        Buffer.from([1, 1, 1, 1])
+      )
+    ).toThrow(
+      `Illegal WellKnownAuthType[${UNKNOWN_RESERVED_AUTH_TYPE}]. Only allowed AuthType should be used`
+    );
+
+    expect(() =>
+      encodeWellKnownAuthMetadata(
+        UNPARSEABLE_AUTH_TYPE,
+        Buffer.from([1, 1, 1, 1])
+      )
+    ).toThrow(
+      `Illegal WellKnownAuthType[${UNPARSEABLE_AUTH_TYPE}]. Only allowed AuthType should be used`
+    );
+  });
+
+  it('should decode AuthMetadata with WellKnownAuthType.SIMPLE in it', () => {
+    const authMetadata = decodeAuthMetadata(
+      Buffer.concat([
+        // eslint-disable-next-line no-bitwise
+        Buffer.from([SIMPLE.identifier | 0x80]),
+        Buffer.from([1, 1, 1, 1]),
+      ])
+    );
+
+    expect(authMetadata).toEqual({
+      payload: Buffer.from([1, 1, 1, 1]),
+      type: {
+        identifier: 0x00,
+        string: 'simple',
+      },
+    });
+  });
+
+  it('should decode AuthMetadata with Custom Auth Type in it', () => {
+    const customAuthType = 'custom/auth/type';
+    const authMetadata = decodeAuthMetadata(
+      Buffer.concat([
+        Buffer.from([customAuthType.length - 1]),
+        Buffer.from(customAuthType),
+        Buffer.from([220, 1]),
+      ])
+    );
+
+    expect(authMetadata).toEqual({
+      payload: Buffer.from([220, 1]),
+      type: {
+        identifier: UNPARSEABLE_AUTH_TYPE.identifier,
+        string: customAuthType,
+      },
+    });
+  });
+
+  it('Should Encode and Decode Simple Auth Metadata', () => {
+    const encodedSimpleAuthMetadata = encodeSimpleAuthMetadata('user', 'pass');
+    const decodedAuthMetadata = decodeAuthMetadata(encodedSimpleAuthMetadata);
+
+    expect(decodedAuthMetadata.type).toEqual({
+      identifier: SIMPLE.identifier,
+      string: SIMPLE.string,
+    });
+
+    expect(decodeSimpleAuthPayload(decodedAuthMetadata.payload)).toEqual({
+      password: Buffer.from('pass'),
+      username: Buffer.from('user'),
+    });
+  });
+});

--- a/packages/rsocket-core/src/__tests__/LiteBuffer-test.js
+++ b/packages/rsocket-core/src/__tests__/LiteBuffer-test.js
@@ -72,10 +72,17 @@ describe('Lite B', () => {
     expect(B.isBuffer(buf1)).toBe(true);
   });
 
-  it('supports utf8 write String', () => {
+  it('supports utf8 write primitive string', () => {
     const buf1 = new B(26);
 
     expect(buf1.write('abcdefghijklmnopqrstuvwxyz')).toBe(26);
+    expect(buf1.toString('utf8')).toEqual('abcdefghijklmnopqrstuvwxyz');
+  });
+
+  it('supports utf8 write object String', () => {
+    const buf1 = new B(26);
+
+    expect(buf1.write(new String('abcdefghijklmnopqrstuvwxyz'))).toBe(26);
     expect(buf1.toString('utf8')).toEqual('abcdefghijklmnopqrstuvwxyz');
   });
 

--- a/packages/rsocket-core/src/__tests__/RoutingMetadata-test.js
+++ b/packages/rsocket-core/src/__tests__/RoutingMetadata-test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+import {encodeRoutes, encodeRoute, decodeRoutes} from '../RoutingMetadata';
+
+describe('Routing Metadata', () => {
+  it('should encode route properly', () => {
+    const routesMetadataBuffer = encodeRoutes('E', '∑', 'é', 'W');
+
+    expect(
+      routesMetadataBuffer.equals(
+        Buffer.from([1, 69, 3, -30, -120, -111, 2, -61, -87, 1, 87])
+      )
+    ).toBe(true);
+  });
+
+  it('should encode empty route properly', () => {
+    const routesMetadataBuffer = encodeRoutes('');
+
+    expect(routesMetadataBuffer.equals(Buffer.from([0]))).toBe(true);
+  });
+
+  it('should throw exception if route longer than 256 symbols', () => {
+    expect(() => {
+      let route = '∑';
+      for (let i = 0; i < 254; i++) {
+        route += 'W';
+      }
+
+      encodeRoute(route);
+    }).toThrow(
+      'route length should fit into unsigned byte length but the given one is 257'
+    );
+  });
+
+  it('should throw exception if routes array is empty', () => {
+    expect(() => {
+      encodeRoutes();
+    }).toThrow('routes should be non empty array');
+  });
+
+  it('should decode route properly', () => {
+    const routesMetadataBuffer = decodeRoutes(
+      Buffer.from([1, 69, 3, -30, -120, -111, 2, -61, -87, 1, 87])
+    );
+
+    expect(routesMetadataBuffer.next()).toEqual({done: false, value: 'E'});
+    expect(routesMetadataBuffer.next()).toEqual({done: false, value: '∑'});
+    expect(routesMetadataBuffer.next()).toEqual({done: false, value: 'é'});
+    expect(routesMetadataBuffer.next()).toEqual({done: false, value: 'W'});
+    expect(routesMetadataBuffer.next()).toEqual({done: true});
+  });
+
+  it('should decode empty route properly', () => {
+    const routesMetadataBuffer = decodeRoutes(Buffer.from([0]));
+
+    expect(routesMetadataBuffer.next()).toEqual({done: false, value: ''});
+    expect(routesMetadataBuffer.next()).toEqual({done: true});
+  });
+
+  it('should fail on decoding malformed buffer', () => {
+    const routesMetadataBuffer = decodeRoutes(Buffer.from([220, 1]));
+    expect(() => routesMetadataBuffer.next()).toThrow(
+      'Malformed RouteMetadata. Offset(1) + RouteLength(220) is greater than TotalLength'
+    );
+  });
+});

--- a/packages/rsocket-core/src/index.js
+++ b/packages/rsocket-core/src/index.js
@@ -157,3 +157,4 @@ export {
   encodeCompositeMetadata,
   decodeCompositeMetadata,
 } from './CompositeMetadata';
+export {encodeRoute, encodeRoutes, decodeRoutes} from './RoutingMetadata';

--- a/packages/rsocket-core/src/index.js
+++ b/packages/rsocket-core/src/index.js
@@ -32,16 +32,24 @@ export type {Serializer, PayloadSerializers} from './RSocketSerialization';
 export type {LeaseStats} from './RSocketLease';
 
 import RSocketClient from './RSocketClient';
+
 export {RSocketClient};
 
 import RSocketServer from './RSocketServer';
+
 export {RSocketServer};
 
 import RSocketResumableTransport from './RSocketResumableTransport';
+
 export {RSocketResumableTransport};
 
 import WellKnownMimeType from './WellKnownMimeType';
+
 export {WellKnownMimeType};
+
+import WellKnownAuthType from './WellKnownAuthType';
+
+export {WellKnownAuthType};
 
 export {
   CONNECTION_STREAM_ID,
@@ -158,3 +166,17 @@ export {
   decodeCompositeMetadata,
 } from './CompositeMetadata';
 export {encodeRoute, encodeRoutes, decodeRoutes} from './RoutingMetadata';
+export {
+  encodeSimpleAuthMetadata,
+  encodeBearerAuthMetadata,
+  encodeWellKnownAuthMetadata,
+  encodeCustomAuthMetadata,
+  decodeSimpleAuthPayload,
+  decodeAuthMetadata,
+} from './AuthMetadata';
+export {
+  UNPARSEABLE_AUTH_TYPE,
+  UNKNOWN_RESERVED_AUTH_TYPE,
+  SIMPLE,
+  BEARER,
+} from './WellKnownAuthType';

--- a/packages/rsocket-core/src/index.js
+++ b/packages/rsocket-core/src/index.js
@@ -154,4 +154,6 @@ export {
   ExplicitMimeTimeEntry,
   encodeAndAddCustomMetadata,
   encodeAndAddWellKnownMetadata,
+  encodeCompositeMetadata,
+  decodeCompositeMetadata,
 } from './CompositeMetadata';


### PR DESCRIPTION
This PR provides support for Routing Metadata and Auth Metadata as well as bring some minor fixes to LiteBuffer + non-breaking refactoring of CompositeMetadata to follow JS usage patterns

closes #88  

Signed-off-by: Oleh Dokuka <shadowgun@i.ua>