### PR TITLE
terminates the stream upon sending an error

### DIFF
--- a/packages/rsocket-core/src/RSocketMachine.js
+++ b/packages/rsocket-core/src/RSocketMachine.js
@@ -854,6 +854,8 @@ class RSocketMachineImpl<D, M> implements RSocketMachine<D, M> {
       streamId,
       type: FRAME_TYPES.ERROR,
     });
+    const error = new Error(`terminated from the requester: ${errorMessage}`);
+    this._handleStreamError(streamId, error);
   }
 
   _sendStreamPayload(


### PR DESCRIPTION
This PR is an attempt to solve https://github.com/rsocket/rsocket-js/issues/115 by explicitly calling `_handleStreamError` after sending an error with `_sendStreamError`. From what I understand, there should not be any unexpected side effects as every receiver is only terminated once. 

The PR also includes a test, where the flow might not be immediately obvious but it effectively replicates the situation described in https://github.com/rsocket/rsocket-java/issues/978. I'm not sure if there is a more concise way to express this scenario. 