### PR TITLE
ensures length and offset are calculated properly

### DIFF
--- a/packages/rsocket-core/src/LiteBuffer.js
+++ b/packages/rsocket-core/src/LiteBuffer.js
@@ -443,7 +443,15 @@ export class Buffer extends Uint8Array {
     byteOffset?: number,
     length?: number,
   ) {
-    super((value: any), byteOffset, length);
+    if (typeof value == 'number') {
+      super(value);
+    } else {
+      const offset = byteOffset || 0;
+      const realLength =
+        //$FlowFixMe
+        length || (isInstance(value, Array) ? value.length : value.byteLength);
+      super((value: any), offset, realLength);
+    }
   }
   /**
    * Allocates a new Buffer of size bytes.


### PR DESCRIPTION
From the private chatting with our users, it turned out that `LiteBuffer` which extends `UInt9Array` may have some issues if it relies on the parent constructor behavior in the case of Safari 12 or 13.

![image](https://user-images.githubusercontent.com/5380167/110156832-1c93bf80-7df0-11eb-8d4f-e2f614f1222f.png)
![image](https://user-images.githubusercontent.com/5380167/110156825-19003880-7df0-11eb-805f-e420357fc091.png)
![image](https://user-images.githubusercontent.com/5380167/110156842-20bfdd00-7df0-11eb-9e78-ef32ab614c53.png)


Signed-off-by: Oleh Dokuka <odokuka@vmware.com>
Signed-off-by: Oleh Dokuka <shadowgun@i.ua>