### PR TITLE
fixes RSocketMachine leak on the server-side

### DIFF
--- a/packages/rsocket-core/src/__tests__/RSocketServer-test.js
+++ b/packages/rsocket-core/src/__tests__/RSocketServer-test.js
@@ -80,6 +80,66 @@ describe('RSocketServer', () => {
     });
   });
 
+  describe('handles connection close', () => {
+    it('removes serverMachine when connection has gone', () => {
+      const transport = genMockTransportServer();
+      const server = new RSocketServer({
+        getRequestHandler: () => {
+          return {};
+        },
+        transport,
+      });
+      server.start();
+      transport.mock.connect();
+      connection.receive.mock.publisher.onNext({
+        type: FRAME_TYPES.SETUP,
+        data: undefined,
+        dataMimeType: '<dataMimeType>',
+        flags: 0,
+        keepAlive: 42,
+        lifetime: 2017,
+        metadata: undefined,
+        metadataMimeType: '<metadataMimeType>',
+        resumeToken: null,
+        streamId: 0,
+        majorVersion: 1,
+        minorVersion: 0,
+      });
+      expect(server._connections.size).toBe(1);
+      connection.close();
+      expect(server._connections.size).toBe(0);
+    });
+
+    it('removes serverMachine when connection has gone with error', () => {
+      const transport = genMockTransportServer();
+      const server = new RSocketServer({
+        getRequestHandler: () => {
+          return {};
+        },
+        transport,
+      });
+      server.start();
+      transport.mock.connect();
+      connection.receive.mock.publisher.onNext({
+        type: FRAME_TYPES.SETUP,
+        data: undefined,
+        dataMimeType: '<dataMimeType>',
+        flags: 0,
+        keepAlive: 42,
+        lifetime: 2017,
+        metadata: undefined,
+        metadataMimeType: '<metadataMimeType>',
+        resumeToken: null,
+        streamId: 0,
+        majorVersion: 1,
+        minorVersion: 0,
+      });
+      expect(server._connections.size).toBe(1);
+      connection.mock.closeWithError(new Error('test'));
+      expect(server._connections.size).toBe(0);
+    });
+  });
+
   describe('RequestHandler', () => {
     it('sends error if getRequestHandler throws', () => {
       const transport = genMockTransportServer();


### PR DESCRIPTION
This PR ensures that the `RSocketServer._connections` `Set` is cleaned when a connection goes away.

Related issue: https://github.com/scalecube/scalecube-js/issues/269 

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>
Signed-off-by: Oleh Dokuka <shadowgun@i.ua>