### PR TITLE
fix: pass required argument to warn call when onNext|onError|onComple…

### DIFF
--- a/packages/rsocket-flowable/src/FlowableProcessor.js
+++ b/packages/rsocket-flowable/src/FlowableProcessor.js
@@ -1,4 +1,4 @@
-import type {IPublisher, ISubscription, ISubscriber} from 'rsocket-types';
+import type { IPublisher, ISubscription, ISubscriber } from 'rsocket-types';
 import warning from 'fbjs/lib/warning';
 
 export default class FlowableProcessor<T, R>
@@ -24,12 +24,11 @@ export default class FlowableProcessor<T, R>
   }
 
   onNext(t: T) {
-    const isPremature = this._subscribed === false;
     warning(
-      isPremature,
+      this._subscribed,
       'Warning, premature onNext for processor, dropping value',
     );
-    if (isPremature) {
+    if (!this._subscribed) {
       return;
     }
 
@@ -46,22 +45,20 @@ export default class FlowableProcessor<T, R>
 
   onError(error: Error) {
     this._error = error;
-    const isPremature = this._subscribed === false;
     warning(
-      isPremature,
+      this._subscribed,
       'Warning, premature onError for processor, marking complete',
     );
-    !isPremature && this._sink.onError(error);
+    this._subscribed && this._sink.onError(error);
   }
 
   onComplete() {
     this._done = true;
-    const isPremature = this._subscribed === false;
     warning(
-      isPremature,
+      this._subscribed,
       'Warning, premature onComplete for processor, marking complete',
     );
-    !isPremature && this._sink.onComplete();
+    this._subscribed && this._sink.onComplete();
   }
 
   subscribe(subscriber: ISubscriber<R>) {

--- a/packages/rsocket-flowable/src/__tests__/FlowableProcessor-test.js
+++ b/packages/rsocket-flowable/src/__tests__/FlowableProcessor-test.js
@@ -1,0 +1,45 @@
+/** Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+import FlowableProcessor from '../FlowableProcessor';
+import {genMockSubscriber} from '../__mocks__/MockFlowableSubscriber';
+
+describe('FlowableProcessor', () => {
+  describe('when subscribe hasnt been called', () => {
+    let processor;
+
+    beforeEach(() => {
+      processor = new FlowableProcessor();
+      processor._sink = genMockSubscriber();
+    });
+
+    it('onNext is a noop call', () => {
+      processor.onNext();
+      expect(processor._sink.onNext.mock.calls.length).toBe(0);
+    });
+
+    it('onComplete is a noop call', () => {
+      processor.onComplete();
+      expect(processor._sink.onComplete.mock.calls.length).toBe(0);
+    });
+
+    it('onError is a noop call', () => {
+      processor.onError();
+      expect(processor._sink.onError.mock.calls.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
fix: pass required argument to warn call when `onNext|onError|onComplete` are called prematurely in `FlowableProcessor`

### Motivation:

Addresses #128 .

### Modifications:

Pass required argument to `fbjs` `warn` call when `onComplete, `onNext or `onError` are called before a `FlowableProcessor` is subscribed to.

### Result:

Premature calls to the above-listed methods will properly log a warning rather than throwing an unrelated error.