### PR TITLE
removes dependency on fbjs from rsocket-core

### DIFF
--- a/packages/rsocket-core/package.json
+++ b/packages/rsocket-core/package.json
@@ -9,7 +9,6 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
-    "fbjs": "^3.0.0",
     "rsocket-flowable": "^0.0.25",
     "rsocket-types": "^0.0.25"
   },

--- a/packages/rsocket-core/src/Invariant.js
+++ b/packages/rsocket-core/src/Invariant.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+'use strict';
+
+/**
+ * Use invariant() to assert state which your program assumes to be true.
+ *
+ * Provide sprintf-style format (only %s is supported) and arguments to provide
+ * information about what broke and what you were expecting.
+ *
+ * The invariant message will be stripped in production, but the invariant will
+ * remain to ensure logic does not differ in production.
+ */
+function invariant(condition: mixed, format: string, ...args: Array<mixed>): void {
+  if (!condition) {
+    let error;
+
+    if (format === undefined) {
+      error = new Error('Minified exception occurred; use the non-minified ' +
+        'dev environment for the full error message and additional helpful warnings.');
+    } else {
+      let argIndex = 0;
+      error = new Error(format.replace(/%s/g, () => String(args[argIndex++])));
+      error.name = 'Invariant Violation';
+    }
+
+    (error: any).framesToPop = 1; // Skip invariant's own stack frame.
+
+    throw error;
+  }
+}
+
+module.exports = invariant;

--- a/packages/rsocket-core/src/RSocketBinaryFraming.js
+++ b/packages/rsocket-core/src/RSocketBinaryFraming.js
@@ -38,7 +38,7 @@ import type {
 } from 'rsocket-types';
 import type {Encoders} from './RSocketEncoding';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from './Invariant';
 import {
   getFrameTypeName,
   isMetadata,

--- a/packages/rsocket-core/src/RSocketClient.js
+++ b/packages/rsocket-core/src/RSocketClient.js
@@ -28,7 +28,7 @@ import type {
 import type {PayloadSerializers} from './RSocketSerialization';
 
 import {Flowable, Single, every} from 'rsocket-flowable';
-import invariant from 'fbjs/lib/invariant';
+import invariant from './Invariant';
 import {CONNECTION_STREAM_ID, FLAGS, FRAME_TYPES} from './RSocketFrame';
 import {MAJOR_VERSION, MINOR_VERSION} from './RSocketVersion';
 import {createClientMachine} from './RSocketMachine';

--- a/packages/rsocket-core/src/RSocketEncoding.js
+++ b/packages/rsocket-core/src/RSocketEncoding.js
@@ -20,7 +20,7 @@
 import type {Encodable} from 'rsocket-types';
 
 import {byteLength} from './RSocketBufferUtils';
-import invariant from 'fbjs/lib/invariant';
+import invariant from './Invariant';
 
 /**
  * Commonly used subset of the allowed Node Buffer Encoder types.

--- a/packages/rsocket-core/src/RSocketFrame.js
+++ b/packages/rsocket-core/src/RSocketFrame.js
@@ -18,9 +18,6 @@
 
 /* eslint-disable max-len, no-bitwise */
 
-import forEachObject from 'fbjs/lib/forEachObject';
-import sprintf from 'fbjs/lib/sprintf';
-
 import type {ErrorFrame, Frame} from 'rsocket-types';
 
 export const CONNECTION_STREAM_ID = 0;
@@ -46,9 +43,10 @@ export const FRAME_TYPES = {
 
 // Maps frame type codes to type names
 export const FRAME_TYPE_NAMES: {[typeCode: number]: string} = {};
-forEachObject(FRAME_TYPES, (value, name) => {
+for (const name in FRAME_TYPES) {
+  const value = FRAME_TYPES[name];
   FRAME_TYPE_NAMES[value] = name;
-});
+}
 
 export const FLAGS = {
   COMPLETE: 0x40, // PAYLOAD, REQUEST_CHANNEL: indicates stream completion, if set onComplete will be invoked on receiver.
@@ -79,9 +77,10 @@ export const ERROR_CODES = {
 
 // Maps error codes to names
 export const ERROR_EXPLANATIONS: {[code: number]: string} = {};
-forEachObject(ERROR_CODES, (code, explanation) => {
+for (const explanation in ERROR_CODES) {
+  const code = ERROR_CODES[explanation];
   ERROR_EXPLANATIONS[code] = explanation;
-});
+}
 
 export const FLAGS_MASK = 0x3ff; // low 10 bits
 export const FRAME_TYPE_OFFFSET = 10; // frame type is offset 10 bytes within the uint16 containing type + flags
@@ -173,6 +172,11 @@ export function getFrameTypeName(type: number): string {
   return name != null ? name : toHex(type);
 }
 
+function sprintf(format, ...args) {
+  let index = 0;
+  return format.replace(/%s/g, match => args[index++]);
+}
+
 /**
  * Constructs an Error object given the contents of an error frame. The
  * `source` property contains metadata about the error for use in introspecting
@@ -224,11 +228,12 @@ export function printFrame(frame: Frame): string {
   const obj: Object = {...frame};
   obj.type = getFrameTypeName(frame.type) + ` (${toHex(frame.type)})`;
   const flagNames = [];
-  forEachObject(FLAGS, (flag, name) => {
+  for (const name in FLAGS) {
+    const flag = FLAGS[name];
     if ((frame.flags & flag) === flag) {
       flagNames.push(name);
     }
-  });
+  }
   if (!flagNames.length) {
     flagNames.push('NO FLAGS');
   }

--- a/packages/rsocket-core/src/RSocketLease.js
+++ b/packages/rsocket-core/src/RSocketLease.js
@@ -18,7 +18,7 @@
 
 import type {Encodable} from 'rsocket-types';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from './Invariant';
 import {Flowable} from 'rsocket-flowable';
 import type {LeaseFrame, ISubscriber, ISubscription} from 'rsocket-types';
 import {MAX_REQUEST_N} from './RSocketFrame';

--- a/packages/rsocket-core/src/RSocketMachine.js
+++ b/packages/rsocket-core/src/RSocketMachine.js
@@ -38,9 +38,6 @@ import type {ISubject, ISubscription, IPartialSubscriber} from 'rsocket-types';
 import type {PayloadSerializers} from './RSocketSerialization';
 
 import {Flowable, FlowableProcessor, Single} from 'rsocket-flowable';
-import emptyFunction from 'fbjs/lib/emptyFunction';
-import invariant from 'fbjs/lib/invariant';
-import warning from 'fbjs/lib/warning';
 import {
   createErrorFromFrame,
   getFrameTypeName,
@@ -314,7 +311,7 @@ class RSocketMachineImpl<D, M> implements RSocketMachine<D, M> {
     const streamId = this._getNextStreamId(this._receivers);
     return new Single(subscriber => {
       this._receivers.set(streamId, {
-        onComplete: emptyFunction,
+        onComplete: () => {},
         onError: error => subscriber.onError(error),
         onNext: data => subscriber.onComplete(data),
       });
@@ -485,11 +482,8 @@ class RSocketMachineImpl<D, M> implements RSocketMachine<D, M> {
                   },
                 });
               } else {
-                warning(
-                  false,
-                  'RSocketClient: re-entrant call to request n before initial' +
-                    ' channel established.',
-                );
+                console.warn('RSocketClient: re-entrant call to request n before initial' +
+                  ' channel established.');
               }
             }
           },
@@ -766,7 +760,7 @@ class RSocketMachineImpl<D, M> implements RSocketMachine<D, M> {
       onSubscribe: cancel => {
         const subscription = {
           cancel,
-          request: emptyFunction,
+          request: () => {},
         };
         this._subscriptions.set(streamId, subscription);
       },

--- a/packages/rsocket-core/src/RSocketResumableTransport.js
+++ b/packages/rsocket-core/src/RSocketResumableTransport.js
@@ -26,7 +26,7 @@ import type {
 import type {ISubject, ISubscription} from 'rsocket-types';
 
 import {Flowable} from 'rsocket-flowable';
-import invariant from 'fbjs/lib/invariant';
+import invariant from './Invariant';
 import {
   createErrorFromFrame,
   isResumePositionFrameType,

--- a/packages/rsocket-core/src/RSocketSerialization.js
+++ b/packages/rsocket-core/src/RSocketSerialization.js
@@ -19,7 +19,7 @@
 import type {Encodable} from 'rsocket-types';
 
 import {LiteBuffer as Buffer} from './LiteBuffer';
-import invariant from 'fbjs/lib/invariant';
+import invariant from './Invariant';
 
 /**
  * A Serializer transforms data between the application encoding used in

--- a/packages/rsocket-core/src/RSocketServer.js
+++ b/packages/rsocket-core/src/RSocketServer.js
@@ -33,7 +33,7 @@ import type {
 import type {PayloadSerializers} from './RSocketSerialization';
 
 import {Flowable} from 'rsocket-flowable';
-import invariant from 'fbjs/lib/invariant';
+import invariant from './Invariant';
 import {
   getFrameTypeName,
   CONNECTION_STREAM_ID,


### PR DESCRIPTION
This PR proposes removing the [fbjs](https://github.com/facebook/fbjs) dependency and removes it from rsocket-core. 

### Motivation:

At the moment, [`fbjs`](https://github.com/facebook/fbjs) is the only major 3rd party dependency. However, very few functions from `fbjs` are actually used - mostly `invariant`. The downside of depending on `fbjs`  is the following transitive closure: 
https://github.com/facebook/fbjs/blob/5300adaec134f532391dfac65d574cc066fe593e/packages/fbjs/package.json#L65-L73. Removing `fbjs` could make rscoket-js effectively a zero dependency package which could facilitate the adoption. 

Additionally, the [README](https://github.com/facebook/fbjs/blob/master/README.md) page of `fbjs` states that "If you are consuming the code here and you are not also a Facebook project, be prepared for a bad time." RSocket-JS is not a Facebook project anymore and therefore might suffer from unexpected compatibility issues. 

### Modifications:

This PR is the first step that removes the dependency from `rsocket-core`. 