### PR TITLE
replace fbjs in flowable/types/ws

### DIFF
--- a/packages/rsocket-examples/package.json
+++ b/packages/rsocket-examples/package.json
@@ -9,7 +9,6 @@
   },
   "license": "BSD-3-Clause",
   "dependencies": {
-    "fbjs": "^3.0.0",
     "rsocket-core": "^0.0.25",
     "rsocket-flowable": "^0.0.25",
     "rsocket-tcp-server": "^0.0.25",

--- a/packages/rsocket-flowable/package.json
+++ b/packages/rsocket-flowable/package.json
@@ -8,8 +8,6 @@
   },
   "license": "BSD-3-Clause",
   "main": "build/index.js",
-  "dependencies": {
-    "fbjs": "^3.0.0"
-  },
+  "dependencies": {},
   "gitHead": "1e15f3c9752f17a06537ee8741900ba12a151a42"
 }

--- a/packages/rsocket-flowable/src/Flowable.js
+++ b/packages/rsocket-flowable/src/Flowable.js
@@ -26,10 +26,8 @@ import type {
 
 import FlowableMapOperator from './FlowableMapOperator';
 import FlowableTakeOperator from './FlowableTakeOperator';
+import invariant from './Invariant';
 
-import invariant from 'fbjs/lib/invariant';
-import warning from 'fbjs/lib/warning';
-import emptyFunction from 'fbjs/lib/emptyFunction';
 
 export type Source<T> = (subscriber: ISubscriber<T>) => void;
 
@@ -75,8 +73,8 @@ export default class Flowable<T> implements IPublisher<T> {
   static never<U = empty>(): Flowable<U> {
     return new Flowable(subscriber => {
       subscriber.onSubscribe({
-        cancel: emptyFunction,
-        request: emptyFunction,
+        cancel: () => {},
+        request: () => {},
       });
     });
   }
@@ -151,8 +149,7 @@ class FlowableSubscriber<T> implements ISubscriber<T> {
 
   onComplete(): void {
     if (!this._active) {
-      warning(
-        false,
+      console.warn(
         'Flowable: Invalid call to onComplete(): %s.',
         this._started
           ? 'onComplete/onError was already called'
@@ -175,8 +172,7 @@ class FlowableSubscriber<T> implements ISubscriber<T> {
 
   onError(error: Error): void {
     if (this._started && !this._active) {
-      warning(
-        false,
+      console.warn(
         'Flowable: Invalid call to onError(): %s.',
         this._active
           ? 'onComplete/onError was already called'
@@ -191,8 +187,7 @@ class FlowableSubscriber<T> implements ISubscriber<T> {
 
   onNext(data: T): void {
     if (!this._active) {
-      warning(
-        false,
+      console.warn(
         'Flowable: Invalid call to onNext(): %s.',
         this._active
           ? 'onComplete/onError was already called'
@@ -201,8 +196,7 @@ class FlowableSubscriber<T> implements ISubscriber<T> {
       return;
     }
     if (this._pending === 0) {
-      warning(
-        false,
+      console.warn(
         'Flowable: Invalid call to onNext(), all request()ed values have been ' +
           'published.',
       );
@@ -223,10 +217,7 @@ class FlowableSubscriber<T> implements ISubscriber<T> {
 
   onSubscribe(subscription?: ?ISubscription): void {
     if (this._started) {
-      warning(
-        false,
-        'Flowable: Invalid call to onSubscribe(): already called.',
-      );
+      console.warn('Flowable: Invalid call to onSubscribe(): already called.');
       return;
     }
     this._active = true;

--- a/packages/rsocket-flowable/src/FlowableMapOperator.js
+++ b/packages/rsocket-flowable/src/FlowableMapOperator.js
@@ -17,8 +17,6 @@
 
 'use strict';
 
-import nullthrows from 'fbjs/lib/nullthrows';
-
 import type {ISubscriber, ISubscription} from 'rsocket-types';
 
 /**
@@ -49,7 +47,10 @@ export default class FlowableMapOperator<T, R> implements ISubscriber<T> {
     try {
       this._subscriber.onNext(this._fn(t));
     } catch (e) {
-      nullthrows(this._subscription).cancel();
+      if (!this._subscription) {
+        throw new Error('subscription is null');
+      }
+      this._subscription.cancel();
       this._subscriber.onError(e);
     }
   }

--- a/packages/rsocket-flowable/src/FlowableProcessor.js
+++ b/packages/rsocket-flowable/src/FlowableProcessor.js
@@ -1,5 +1,4 @@
 import type {IPublisher, ISubscription, ISubscriber} from 'rsocket-types';
-import warning from 'fbjs/lib/warning';
 
 export default class FlowableProcessor<T, R>
   implements IPublisher<R>, ISubscriber<T>, ISubscription {
@@ -23,7 +22,7 @@ export default class FlowableProcessor<T, R>
 
   onNext(t: T) {
     if (!this._sink) {
-      warning('Warning, premature onNext for processor, dropping value');
+      console.warn('premature onNext for processor, dropping value');
       return;
     }
 
@@ -41,9 +40,7 @@ export default class FlowableProcessor<T, R>
   onError(error: Error) {
     this._error = error;
     if (!this._sink) {
-      warning(
-        'Warning, premature onError for processor, marking complete/errored',
-      );
+      console.warn('premature onError for processor, marking complete/errored');
     } else {
       this._sink.onError(error);
     }
@@ -52,7 +49,7 @@ export default class FlowableProcessor<T, R>
   onComplete() {
     this._done = true;
     if (!this._sink) {
-      warning('Warning, premature onError for processor, marking complete');
+      console.warn('premature onError for processor, marking complete');
     } else {
       this._sink.onComplete();
     }

--- a/packages/rsocket-flowable/src/FlowableTakeOperator.js
+++ b/packages/rsocket-flowable/src/FlowableTakeOperator.js
@@ -17,8 +17,6 @@
 
 'use strict';
 
-import nullthrows from 'fbjs/lib/nullthrows';
-
 import type {ISubscriber, ISubscription} from 'rsocket-types';
 
 /**
@@ -52,7 +50,10 @@ export default class FlowableTakeOperator<T> implements ISubscriber<T> {
         this._cancelAndComplete();
       }
     } catch (e) {
-      nullthrows(this._subscription).cancel();
+      if (!this._subscription) {
+        throw new Error('subscription is null');
+      }
+      this._subscription.cancel();
       this._subscriber.onError(e);
     }
   }
@@ -66,7 +67,10 @@ export default class FlowableTakeOperator<T> implements ISubscriber<T> {
   }
 
   _cancelAndComplete(): void {
-    nullthrows(this._subscription).cancel();
+    if (!this._subscription) {
+      throw new Error('subscription is null');
+    }
+    this._subscription.cancel();
     this._subscriber.onComplete();
   }
 }

--- a/packages/rsocket-flowable/src/Invariant.js
+++ b/packages/rsocket-flowable/src/Invariant.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+'use strict';
+
+/**
+ * Use invariant() to assert state which your program assumes to be true.
+ *
+ * Provide sprintf-style format (only %s is supported) and arguments to provide
+ * information about what broke and what you were expecting.
+ *
+ * The invariant message will be stripped in production, but the invariant will
+ * remain to ensure logic does not differ in production.
+ */
+function invariant(condition: mixed, format: string, ...args: Array<mixed>): void {
+  if (!condition) {
+    let error;
+
+    if (format === undefined) {
+      error = new Error('Minified exception occurred; use the non-minified ' +
+        'dev environment for the full error message and additional helpful warnings.');
+    } else {
+      let argIndex = 0;
+      error = new Error(format.replace(/%s/g, () => String(args[argIndex++])));
+      error.name = 'Invariant Violation';
+    }
+
+    (error: any).framesToPop = 1; // Skip invariant's own stack frame.
+
+    throw error;
+  }
+}
+
+module.exports = invariant;

--- a/packages/rsocket-flowable/src/Single.js
+++ b/packages/rsocket-flowable/src/Single.js
@@ -17,9 +17,6 @@
 
 'use strict';
 
-import warning from 'fbjs/lib/warning';
-import emptyFunction from 'fbjs/lib/emptyFunction';
-
 export type Source<T> = (subject: IFutureSubject<T>) => void;
 
 export type CancelCallback = () => void;
@@ -152,8 +149,8 @@ export default class Single<T> {
 
   then(successFn?: (data: T) => void, errorFn?: (error: Error) => void): void {
     this.subscribe({
-      onComplete: successFn || emptyFunction,
-      onError: errorFn || emptyFunction,
+      onComplete: successFn || (() => {}),
+      onError: errorFn || (() => {}),
     });
   }
 }
@@ -174,8 +171,7 @@ class FutureSubscriber<T> implements IFutureSubscriber<T> {
 
   onComplete(value: T): void {
     if (!this._active) {
-      warning(
-        false,
+      console.warn(
         'Single: Invalid call to onComplete(): %s.',
         this._started
           ? 'onComplete/onError was already called'
@@ -198,8 +194,7 @@ class FutureSubscriber<T> implements IFutureSubscriber<T> {
 
   onError(error: Error): void {
     if (this._started && !this._active) {
-      warning(
-        false,
+      console.warn(
         'Single: Invalid call to onError(): %s.',
         this._active
           ? 'onComplete/onError was already called'
@@ -214,7 +209,7 @@ class FutureSubscriber<T> implements IFutureSubscriber<T> {
 
   onSubscribe(cancel?: ?CancelCallback): void {
     if (this._started) {
-      warning(false, 'Single: Invalid call to onSubscribe(): already called.');
+      console.warn('Single: Invalid call to onSubscribe(): already called.');
       return;
     }
     this._active = true;

--- a/packages/rsocket-flowable/src/__mocks__/MockFlowableSubscriber.js
+++ b/packages/rsocket-flowable/src/__mocks__/MockFlowableSubscriber.js
@@ -15,8 +15,6 @@
 
 'use strict';
 
-import emptyFunction from 'fbjs/lib/emptyFunction';
-
 import type {Subscriber} from '../../ReactiveStreamTypes';
 
 type PartialSubscriber<T> = {|
@@ -32,9 +30,9 @@ export function genMockSubscriber<T>(
   let subscription;
   partialSubscriber = partialSubscriber || {};
   const subscriber = {
-    onComplete: jest.fn(partialSubscriber.onComplete || emptyFunction),
-    onError: jest.fn(partialSubscriber.onError || emptyFunction),
-    onNext: jest.fn(partialSubscriber.onNext || emptyFunction),
+    onComplete: jest.fn(partialSubscriber.onComplete || (() => {})),
+    onError: jest.fn(partialSubscriber.onError || (() => {})),
+    onNext: jest.fn(partialSubscriber.onNext || (() => {})),
     onSubscribe: jest.fn(sub => {
       partialSubscriber.onSubscribe && partialSubscriber.onSubscribe(sub);
       subscription = sub;

--- a/packages/rsocket-flowable/src/__tests__/Flowable-test.js
+++ b/packages/rsocket-flowable/src/__tests__/Flowable-test.js
@@ -15,12 +15,12 @@
 
 'use strict';
 
-jest.mock('fbjs/lib/warning').useFakeTimers();
+jest.useFakeTimers();
 
 describe('Flowable', () => {
   const Flowable = require('../Flowable').default;
   const {genMockSubscriber} = require('../__mocks__/MockFlowableSubscriber');
-  const warning = require('fbjs/lib/warning');
+  const warning = jest.spyOn(global.console, 'warn');
 
   beforeEach(() => {
     warning.mockClear();

--- a/packages/rsocket-flowable/src/__tests__/Single-test.js
+++ b/packages/rsocket-flowable/src/__tests__/Single-test.js
@@ -15,11 +15,11 @@
 
 'use strict';
 
-jest.mock('fbjs/lib/warning').useFakeTimers();
+jest.useFakeTimers();
 
 describe('Single', () => {
   const Single = require('../Single').default;
-  const warning = require('fbjs/lib/warning');
+  const warning = jest.spyOn(global.console, 'warn');
 
   it('evaluates the single lazily', () => {
     const builder = jest.fn();

--- a/packages/rsocket-types/package.json
+++ b/packages/rsocket-types/package.json
@@ -9,7 +9,6 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
-    "fbjs": "^3.0.0",
     "rsocket-flowable": "^0.0.25"
   },
   "gitHead": "1e15f3c9752f17a06537ee8741900ba12a151a42"

--- a/packages/rsocket-websocket-client/package.json
+++ b/packages/rsocket-websocket-client/package.json
@@ -9,7 +9,6 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
-    "fbjs": "^3.0.0",
     "rsocket-core": "^0.0.25",
     "rsocket-flowable": "^0.0.25",
     "rsocket-types": "^0.0.25"

--- a/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js
+++ b/packages/rsocket-websocket-client/src/RSocketWebSocketClient.js
@@ -21,7 +21,6 @@ import type {ConnectionStatus, DuplexConnection, Frame} from 'rsocket-types';
 import type {ISubject, ISubscriber, ISubscription} from 'rsocket-types';
 import type {Encoders} from 'rsocket-core';
 
-import invariant from 'fbjs/lib/invariant';
 import {Flowable} from 'rsocket-flowable';
 import {
   deserializeFrame,
@@ -67,11 +66,10 @@ export default class RSocketWebSocketClient implements DuplexConnection {
   }
 
   connect(): void {
-    invariant(
-      this._status.kind === 'NOT_CONNECTED',
-      'RSocketWebSocketClient: Cannot connect(), a connection is already ' +
-        'established.',
-    );
+    if (this._status.kind !== 'NOT_CONNECTED') {
+      throw new Error('RSocketWebSocketClient: Cannot connect(), a connection is already ' +
+        'established.');
+    }
     this._setConnectionStatus(CONNECTION_STATUS.CONNECTING);
 
     const wsCreator = this._options.wsCreator;
@@ -218,10 +216,9 @@ export default class RSocketWebSocketClient implements DuplexConnection {
       const buffer = this._options.lengthPrefixedFrames
         ? serializeFrameWithLength(frame, this._encoders)
         : serializeFrame(frame, this._encoders);
-      invariant(
-        this._socket,
-        'RSocketWebSocketClient: Cannot send frame, not connected.',
-      );
+      if (!this._socket) {
+        throw new Error('RSocketWebSocketClient: Cannot send frame, not connected.');
+      }
       this._socket.send(buffer);
     } catch (error) {
       this._close(error);


### PR DESCRIPTION
This PR is a continuation of https://github.com/rsocket/rsocket-js/pull/133. In this PR, `fbjs` is removed from: 
* `rsocket-examples`
* `rsocket-flowable`
* `rsocket-types`
* `rsocket-websocket-client` 
