### PR TITLE
remove fbjs from tck/websocket-server

### DIFF
--- a/examples/RSocketExampleConditionalRequestClient.js
+++ b/examples/RSocketExampleConditionalRequestClient.js
@@ -6,7 +6,6 @@
  * LICENSE-examples file in the root directory of this source tree.
  */
 
-import Deferred from 'fbjs/lib/Deferred';
 import {RSocketClient} from 'rsocket-core';
 import RSocketTcpClient from 'rsocket-tcp-client';
 
@@ -50,34 +49,34 @@ async function run(options) {
   const socket = await connect(options);
   let pending = 5;
   let subscription;
-  const deferred = new Deferred();
-  socket.requestStream({
-    data: 'Joe',
-    metadata: null,
-  }).subscribe({
-    onComplete() {
-      deferred.resolve();
-      console.log('onComplete()');
-    },
-    onError(error) {
-      console.log('onError(%s)', error.message);
-      deferred.reject(error);
-    },
-    onNext(payload) {
-      console.log('onNext(%s)', payload.data);
-      if (--pending === 0) {
-        console.log('cancel()');
-        subscription.cancel();
-        deferred.resolve();
-      }
-    },
-    onSubscribe(_subscription) {
-      console.log('requestStream(%s)', pending);
-      subscription = _subscription;
-      subscription.request(pending);
-    },
+  return new Promise((resolve, reject) => {
+    socket.requestStream({
+      data: 'Joe',
+      metadata: null,
+    }).subscribe({
+      onComplete() {
+        resolve();
+        console.log('onComplete()');
+      },
+      onError(error) {
+        console.log('onError(%s)', error.message);
+        reject(error);
+      },
+      onNext(payload) {
+        console.log('onNext(%s)', payload.data);
+        if (--pending === 0) {
+          console.log('cancel()');
+          subscription.cancel();
+          resolve();
+        }
+      },
+      onSubscribe(_subscription) {
+        console.log('requestStream(%s)', pending);
+        subscription = _subscription;
+        subscription.request(pending);
+      },
+    });
   });
-  return deferred.getPromise();
 }
 
 async function connect(options) {

--- a/packages/rsocket-tck/package.json
+++ b/packages/rsocket-tck/package.json
@@ -9,7 +9,6 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
-    "fbjs": "^3.0.0",
     "rsocket-core": "^0.0.25",
     "rsocket-flowable": "^0.0.25",
     "rsocket-tcp-client": "^0.0.25"

--- a/packages/rsocket-tck/src/Deferred.js
+++ b/packages/rsocket-tck/src/Deferred.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @providesModule Deferred
+ * @typechecks
+ * @flow
+ */
+
+/**
+ * Deferred provides a Promise-like API that exposes methods to resolve and
+ * reject the Promise. It is most useful when converting non-Promise code to use
+ * Promises.
+ *
+ * If you want to export the Promise without exposing access to the resolve and
+ * reject methods, you should export `getPromise` which returns a Promise with
+ * the same semantics excluding those methods.
+ */
+export class Deferred<Tvalue, Treason> {
+  _settled: boolean;
+  _promise: Promise<any>;
+  _resolve: (value: Tvalue) => void;
+  _reject: (reason: Treason) => void;
+
+  constructor() {
+    this._settled = false;
+    this._promise = new Promise((resolve, reject) => {
+      this._resolve = (resolve: any);
+      this._reject = (reject: any);
+    });
+  }
+
+  getPromise(): Promise<any> {
+    return this._promise;
+  }
+
+  resolve(value: Tvalue): void {
+    this._settled = true;
+
+    this._resolve(value);
+  }
+
+  reject(reason: Treason): void {
+    this._settled = true;
+
+    this._reject(reason);
+  }
+
+  catch(onReject?: ?(error: any) => mixed): Promise<any> {
+    return Promise.prototype.catch.apply(this._promise, arguments);
+  }
+
+  then(onFulfill?: ?(value: any) => mixed, onReject?: ?(error: any) => mixed): Promise<any> {
+    return Promise.prototype.then.apply(this._promise, arguments);
+  }
+
+  done(onFulfill?: ?(value: any) => mixed, onReject?: ?(error: any) => mixed): void {
+    // Embed the polyfill for the non-standard Promise.prototype.done so that
+    // users of the open source fbjs don't need a custom lib for Promise
+    const promise = arguments.length
+      ? this._promise.then.apply(this._promise, arguments)
+      : this._promise;
+    promise.then(undefined, err => {
+      setTimeout(() => {
+        throw err;
+      }, 0);
+    });
+  }
+
+  isSettled(): boolean {
+    return this._settled;
+  }
+}

--- a/packages/rsocket-tck/src/RSocketTckClient.js
+++ b/packages/rsocket-tck/src/RSocketTckClient.js
@@ -20,16 +20,29 @@ import RSocketTcpClient from 'rsocket-tcp-client';
 import RSocketTckRequestResponseSubscriber from './RSocketTckRequestResponseSubscriber';
 import RSocketTckRequestStreamSubscriber from './RSocketTckRequestStreamSubscriber';
 
-import areEqual from 'fbjs/lib/areEqual';
 import chalk from 'chalk';
 import fs from 'fs';
-import nullthrows from 'fbjs/lib/nullthrows';
 import path from 'path';
-import sprintf from 'fbjs/lib/sprintf';
 import util from 'util';
 import yargs from 'yargs';
 
 import type {Payload, ReactiveSocket} from 'rsocket-types';
+
+function sprintf(format, ...args) {
+  let index = 0;
+  return format.replace(/%s/g, () => '' + args[index++]);
+}
+
+function nullthrows(x) {
+  if (x != null) {
+    return x;
+  }
+  throw new Error('got null or undefined');
+}
+
+function areEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
 
 type Options = {
   host: string,
@@ -86,10 +99,8 @@ async function run(options: Options): Promise<void> {
     );
   }
   process.stdout.write(chalk.inverse('Running TCK tests') + '\n');
-  process.stdout.write(sprintf('Using testfile %s', testfilePath) + '\n');
-  process.stdout.write(
-    sprintf('Connecting to server at %s:%s', options.host, options.port) + '\n',
-  );
+  process.stdout.write(`Using testfile${testfilePath}\n`);
+  process.stdout.write(`Connecting to server at ${options.host}:${options.port}\n`);
   const testSource = fs.readFileSync(testfilePath, 'utf8');
   const testCases = testSource
     .split('!')

--- a/packages/rsocket-tck/src/RSocketTckRequestResponseSubscriber.js
+++ b/packages/rsocket-tck/src/RSocketTckRequestResponseSubscriber.js
@@ -15,11 +15,8 @@
  * @flow
  */
 
-import Deferred from 'fbjs/lib/Deferred';
-
-import nullthrows from 'fbjs/lib/nullthrows';
-
 import type {Payload} from 'rsocket-types';
+import {Deferred} from './Deferred';
 
 export default class RSocketTckRequestResponseSubscriber {
   _cancelled: boolean;
@@ -81,7 +78,10 @@ export default class RSocketTckRequestResponseSubscriber {
 
   cancel(): void {
     this._cancelled = true;
-    nullthrows(this._subscription).cancel();
+    if (!this._subscription) {
+      throw new Error('subscription is null or undefined');
+    }
+    this._subscription.cancel();
   }
 
   request(n: number): void {

--- a/packages/rsocket-tck/src/RSocketTckRequestStreamSubscriber.js
+++ b/packages/rsocket-tck/src/RSocketTckRequestStreamSubscriber.js
@@ -15,12 +15,9 @@
  * @flow
  */
 
-import Deferred from 'fbjs/lib/Deferred';
-
-import nullthrows from 'fbjs/lib/nullthrows';
-
 import type {Payload} from 'rsocket-types';
 import type {ISubscriber, ISubscription} from 'rsocket-types';
+import {Deferred} from './Deferred';
 
 export default class RSocketTckRequestStreamSubscriber
   implements ISubscriber<Payload<*, *>> {
@@ -83,11 +80,17 @@ export default class RSocketTckRequestStreamSubscriber
 
   cancel(): void {
     this._cancelled = true;
-    nullthrows(this._subscription).cancel();
+    if (!this._subscription) {
+      throw new Error('subscription is null or undefined');
+    }
+    this._subscription.cancel();
   }
 
   request(n: number): void {
-    nullthrows(this._subscription).request(n);
+    if (!this._subscription) {
+      throw new Error('subscription is null or undefined');
+    }
+    this._subscription.request(n);
   }
 
   onComplete(): void {

--- a/packages/rsocket-tcp-client/package.json
+++ b/packages/rsocket-tcp-client/package.json
@@ -9,7 +9,6 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
-    "fbjs": "^3.0.0",
     "rsocket-core": "^0.0.25",
     "rsocket-flowable": "^0.0.25",
     "rsocket-types": "^0.0.25"

--- a/packages/rsocket-tcp-client/src/RSocketTcpClient.js
+++ b/packages/rsocket-tcp-client/src/RSocketTcpClient.js
@@ -24,7 +24,6 @@ import type {Encoders} from 'rsocket-core';
 import net from 'net';
 import tls from 'tls';
 import {Flowable} from 'rsocket-flowable';
-import invariant from 'fbjs/lib/invariant';
 import {
   createBuffer,
   deserializeFrames,
@@ -188,10 +187,9 @@ export class RSocketTcpConnection implements DuplexConnection {
   _writeFrame(frame: Frame): void {
     try {
       const buffer = serializeFrameWithLength(frame, this._encoders);
-      invariant(
-        this._socket,
-        'RSocketTcpClient: Cannot send frame, not connected.',
-      );
+      if (!this._socket) {
+        throw new Error('RSocketTcpClient: Cannot send frame, not connected.');
+      }
       this._socket.write(buffer);
     } catch (error) {
       this._handleError(error);
@@ -211,11 +209,9 @@ export class RSocketTcpClient extends RSocketTcpConnection {
   }
 
   connect(): void {
-    invariant(
-      this.getConnectionState().kind === 'NOT_CONNECTED',
-      'RSocketTcpClient: Cannot connect(), a connection is already ' +
-        'established.',
-    );
+    if (this.getConnectionState().kind !== 'NOT_CONNECTED') {
+      throw new Error('RSocketTcpClient: Cannot connect(), a connection is already established.');
+    }
     this.setConnectionStatus(CONNECTION_STATUS.CONNECTING);
     const socket = net.connect(this._options);
 
@@ -240,11 +236,9 @@ export class RSocketTlsClient extends RSocketTcpConnection {
   }
 
   connect(): void {
-    invariant(
-      this.getConnectionState().kind === 'NOT_CONNECTED',
-      'RSocketTlsClient: Cannot connect(), a connection is already ' +
-        'established.',
-    );
+    if (this.getConnectionState().kind !== 'NOT_CONNECTED') {
+      throw new Error('RSocketTcpClient: Cannot connect(), a connection is already established.');
+    }
     this.setConnectionStatus(CONNECTION_STATUS.CONNECTING);
     const socket = tls.connect(this._options);
 

--- a/packages/rsocket-tcp-server/package.json
+++ b/packages/rsocket-tcp-server/package.json
@@ -9,7 +9,6 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
-    "fbjs": "^3.0.0",
     "rsocket-core": "^0.0.25",
     "rsocket-flowable": "^0.0.25",
     "rsocket-tcp-client": "^0.0.25",

--- a/packages/rsocket-websocket-server/package.json
+++ b/packages/rsocket-websocket-server/package.json
@@ -9,7 +9,6 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
-    "fbjs": "^2.0.0",
     "rsocket-core": "^0.0.25",
     "rsocket-flowable": "^0.0.25",
     "rsocket-types": "^0.0.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3348,11 +3348,6 @@ core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-js@^3.6.4:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
-  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -4246,20 +4241,6 @@ fbjs-scripts@^3.0.0:
     plugin-error "^0.1.2"
     semver "^5.1.0"
     through2 "^2.0.0"
-
-fbjs@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-2.0.0.tgz#01fb812138d7e31831ed3e374afe27b9169ef442"
-  integrity sha512-8XA8ny9ifxrAWlyhAbexXcs3rRMtxWcs3M0lctLfB49jRDHiaxj+Mo0XxbwE7nKZYzgCFoq64FS+WFd4IycPPQ==
-  dependencies:
-    core-js "^3.6.4"
-    cross-fetch "^3.0.4"
-    fbjs-css-vars "^1.0.0"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
 
 fbjs@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR is a continuation of #134. In this PR, fbjs is removed from:

* rsocket-tck
* rsocket-tcp-client
* rsocket-tcp-server
* rsocket-websocket-server

None of the artifacts depends on `fbjs` now. The only remaining usage of the dependency is the jest test configuration. 

`rsocket-tck` was covered by tests, so I ran it manually with `yarn tck`. However, the only place where I found the compatible TCK was https://github.com/rsocket/rsocket-tck/pull/35 - I couldn't find a way to run the JS tck against any other server. 
```
rsocket-js % yarn tck
yarn run v1.22.4
$ yarn run build && node ./packages/rsocket-tck/build/index.js "$@"
$ cross-env NODE_ENV=production node ./scripts/build.js
Building packages
=> rsocket-core (npm)
=> rsocket-examples (npm)
=> rsocket-flowable (npm)
=> rsocket-tck (npm)
=> rsocket-tcp-client (npm)
=> rsocket-tcp-server (npm)
=> rsocket-types (npm)
=> rsocket-websocket-client (npm)
=> rsocket-websocket-server (npm)
Warning for package rsocket-websocket-client
Entry module "packages/rsocket-websocket-client/src/index.js" is implicitly using "default" export mode, which means for CommonJS output that its default export is assigned to "module.exports". For many tools, such CommonJS output will not be interchangeable with the original ES module. If this is intended, explicitly set "output.exports" to either "auto" or "default", otherwise you might want to consider changing the signature of "packages/rsocket-websocket-client/src/index.js" to use named exports only.
=> rsocket-websocket-client (haste)
=> rsocket-types (haste)
=> rsocket-flowable (haste)
Warning for package rsocket-core
'buffer' is imported by packages/rsocket-core/src/LiteBuffer.js, but could not be resolved – treating it as an external dependency
Warning for package rsocket-core
Non-existent export 'LeaseHandler' is imported from packages/rsocket-core/src/RSocketLease.js
Warning for package rsocket-core
Non-existent export 'Disposable' is imported from packages/rsocket-core/src/RSocketLease.js
=> rsocket-core (haste)
Running TCK tests
Using testfile/Users/sergey/git/rsocket-js/packages/rsocket-tck/build/clienttest.txt
Connecting to server at 127.0.0.1:9898
All tests pass.
✨  Done in 13.32s.
```