### PR TITLE
moves multiplexing/demultiplexing to the DuplexConnection level

### DIFF
--- a/packages/rsocket-core/src/ClientServerMultiplexerDemultiplexer.ts
+++ b/packages/rsocket-core/src/ClientServerMultiplexerDemultiplexer.ts
@@ -1,9 +1,7 @@
-import { RSocketError } from ".";
+import { Deferred, Demultiplexer, Multiplexer, Stream } from ".";
 import { Closeable } from "./Common";
-import { ErrorCodes } from "./Errors";
 import {
   ErrorFrame,
-  Flags,
   Frame,
   FrameTypes,
   KeepAliveFrame,
@@ -18,284 +16,69 @@ import {
   SetupFrame,
 } from "./Frames";
 import {
-  RequestChannelRequesterStream,
-  RequestChannelResponderStream,
-} from "./RequestChannelStream";
-import {
-  RequestFnFRequesterHandler,
-  RequestFnfResponderHandler,
-} from "./RequestFnFStream";
-import {
-  RequestResponseRequesterStream,
-  RequestResponseResponderStream,
-} from "./RequestResponseStream";
-import {
-  RequestStreamRequesterStream,
-  RequestStreamResponderStream,
-} from "./RequestStreamStream";
-import {
-  Cancellable,
-  OnExtensionSubscriber,
-  OnNextSubscriber,
-  OnTerminalSubscriber,
-  Payload,
-  Requestable,
-  RSocket,
-  SocketAcceptor,
-  StreamFrameHandler,
-  StreamLifecycleHandler,
-  StreamsRegistry,
-} from "./RSocket";
-import {
-  DuplexConnection,
-  FlowControl,
-  FlowControlledFrameHandler,
   FrameHandler,
   Outbound,
+  StreamFrameHandler,
+  StreamLifecycleHandler,
 } from "./Transport";
 
-type ServerConfig = {
-  fragmentSize: number;
-  keepAlive: {
-    hasSender: boolean;
-  };
-  streamIdSupplier: (occupiedIds: Array<number>) => number;
-  acceptor: SocketAcceptor;
-};
-
-type ClientConfig = {
-  fragmentSize: number;
-  keepAlive: {
-    timeout: number;
-    period: number;
-  };
-  streamIdSupplier: (occupiedIds: Array<number>) => number;
-  responder: Partial<RSocket>;
-};
-
-function isServerConfig(
-  config: ClientConfig | ServerConfig
-): config is ServerConfig {
-  return config["acceptor"] !== undefined;
+export interface StreamIdGenerator {
+  next(handler: (nextId: number) => boolean, streams: Array<number>): void;
 }
 
-export class ClientServerInputMultiplexerDemultiplexer
-  implements Closeable, StreamsRegistry, FlowControlledFrameHandler {
-  private done: boolean;
+export namespace StreamIdGenerator {
+  export function create(seedId: number): StreamIdGenerator {
+    return new StreamIdGeneratorImpl(seedId);
+  }
+
+  class StreamIdGeneratorImpl implements StreamIdGenerator {
+    constructor(private currentId: number) {}
+
+    next(handler: (nextId: number) => boolean): void {
+      const nextId = this.currentId + 2;
+
+      if (!handler(nextId)) {
+        return;
+      }
+
+      this.currentId = nextId;
+    }
+  }
+}
+
+export abstract class ClientServerInputMultiplexerDemultiplexer
+  extends Deferred
+  implements
+    Closeable,
+    Multiplexer,
+    Demultiplexer,
+    Stream,
+    Outbound,
+    FrameHandler {
   private readonly registry: { [id: number]: StreamFrameHandler } = {};
-  private readonly config: ClientConfig | ServerConfig;
 
-  private delegateHandler: FlowControlledFrameHandler & {
-    close: (error?: Error) => void;
-  };
-
-  constructor(
-    private readonly connection: DuplexConnection,
-    config: ClientConfig | ServerConfig
-  ) {
-    this.config = config;
-    this.delegateHandler = isServerConfig(config)
-      ? new SetupFrameHandler(this, connection, config)
-      : new GenericFrameHandler(
-          new RequestFrameHandler(
-            this,
-            connection,
-            config.fragmentSize,
-            config.responder
-          ),
-          new ConnectionFrameHandler(
-            this,
-            new KeepAliveHandler(this, connection, config.keepAlive.timeout),
-            config.responder
-          ),
-          this,
-          new KeepAliveSender(connection, config.keepAlive.period)
-        );
-
-    connection.onClose(this.clean.bind(this));
-    connection.handle(this);
-  }
-
-  handle(frame: Frame, callback?: (controlRequest: FlowControl) => void): void {
-    this.delegateHandler.handle(frame, callback);
-  }
-
-  get(streamId: number): StreamFrameHandler {
-    return this.registry[streamId];
-  }
-
-  add(handler: StreamFrameHandler, streamId: number): void;
-  add(handler: StreamFrameHandler & StreamLifecycleHandler): void;
-  add(handler: StreamFrameHandler, providedStreamId?: number): void {
-    if (providedStreamId !== undefined) {
-      // handle responder side stream registration
-      this.registry[providedStreamId] = handler;
-      return;
-    }
-
-    // handle requester side stream registration
-    const stream = handler as StreamFrameHandler & StreamLifecycleHandler;
-    if (this.done) {
-      stream.handleReject(new Error("Already closed"));
-      return;
-    }
-
-    const registry = this.registry;
-    const streamId = this.config.streamIdSupplier(
-      (Object.keys(registry) as any) as Array<number>
-    );
-
-    this.registry[streamId] = stream;
-
-    if (
-      !stream.handleReady(streamId, {
-        outbound: this.connection,
-        fragmentSize: this.config.fragmentSize,
-      })
-    ) {
-      // TODO: return stream id
-    }
-  }
-
-  remove(stream: StreamFrameHandler): void {
-    delete this.registry[stream.streamId];
-  }
-
-  close(error?: Error): void {
-    if (this.done) {
-      console.warn(
-        `Trying to close for the second time. ${
-          error ? `Dropping error [${error}].` : ""
-        }`
-      );
-      return;
-    }
-
-    this.clean(error);
-
-    this.connection.close(error);
-  }
-
-  private clean(error?: Error): void {
-    if (this.done) {
-      return;
-    }
-
-    this.done = true;
-
-    for (const streamId in this.registry) {
-      const stream = this.registry[streamId];
-
-      stream.close(
-        new Error(`Closed. ${error ? `Original cause [${error}].` : ""}`)
-      );
-    }
-
-    this.delegateHandler.close(error);
-  }
-
-  onClose(callback): void {
-    this.connection.onClose(callback);
-  }
-}
-
-class RequestFrameHandler implements FrameHandler {
-  constructor(
-    private registry: StreamsRegistry,
-    private outbound: Outbound,
-    private fragmentSize: number,
-    private rsocket: Partial<RSocket>
-  ) {}
-
-  handle(
+  private connectionFramesHandler: (
+    frame:
+      | SetupFrame
+      | ResumeFrame
+      | ResumeOkFrame
+      | LeaseFrame
+      | KeepAliveFrame
+      | ErrorFrame
+      | MetadataPushFrame
+  ) => void;
+  private requestFramesHandler: (
     frame:
       | RequestFnfFrame
       | RequestResponseFrame
       | RequestStreamFrame
-      | RequestChannelFrame
-  ): void {
-    switch (frame.type) {
-      case FrameTypes.REQUEST_FNF:
-        if (this.rsocket.fireAndForget) {
-          new RequestFnfResponderHandler(
-            frame.streamId,
-            this.registry,
-            this.rsocket.fireAndForget.bind(this.rsocket),
-            frame
-          );
-        }
-        return;
-      case FrameTypes.REQUEST_RESPONSE:
-        if (this.rsocket.requestResponse) {
-          new RequestResponseResponderStream(
-            frame.streamId,
-            this.registry,
-            this.outbound,
-            this.fragmentSize,
-            this.rsocket.requestResponse.bind(this.rsocket),
-            frame
-          );
-          return;
-        }
+      | RequestChannelFrame,
+    stream: Outbound & Stream
+  ) => boolean;
 
-        this.rejectRequest(frame.streamId);
-
-        return;
-
-      case FrameTypes.REQUEST_STREAM:
-        if (this.rsocket.requestStream) {
-          new RequestStreamResponderStream(
-            frame.streamId,
-            this.registry,
-            this.outbound,
-            this.fragmentSize,
-            this.rsocket.requestStream.bind(this.rsocket),
-            frame
-          );
-          return;
-        }
-
-        this.rejectRequest(frame.streamId);
-
-        return;
-
-      case FrameTypes.REQUEST_CHANNEL:
-        if (this.rsocket.requestChannel) {
-          new RequestChannelResponderStream(
-            frame.streamId,
-            this.registry,
-            this.outbound,
-            this.fragmentSize,
-            this.rsocket.requestChannel.bind(this.rsocket),
-            frame
-          );
-          return;
-        }
-
-        this.rejectRequest(frame.streamId);
-
-        return;
-    }
+  constructor(private readonly streamIdSupplier: StreamIdGenerator) {
+    super();
   }
-
-  rejectRequest(streamId: number) {
-    this.outbound.send({
-      type: FrameTypes.ERROR,
-      streamId,
-      flags: Flags.NONE,
-      code: ErrorCodes.REJECTED,
-      message: "No available handler found",
-    });
-  }
-}
-
-class GenericFrameHandler implements FlowControlledFrameHandler {
-  constructor(
-    private requestHandler: RequestFrameHandler,
-    private connectionHandler: ConnectionFrameHandler,
-    private registry: StreamsRegistry,
-    private keepAliveSender: KeepAliveSender | undefined
-  ) {}
 
   handle(frame: Frame): void {
     if (frame.type === FrameTypes.RESERVED) {
@@ -304,17 +87,17 @@ class GenericFrameHandler implements FlowControlledFrameHandler {
     }
 
     if (Frame.isConnection(frame)) {
-      this.connectionHandler.handle(frame);
+      this.connectionFramesHandler(frame);
       // TODO: Connection Handler
     } else if (Frame.isRequest(frame)) {
-      if (this.registry.get(frame.streamId)) {
+      if (this.registry[frame.streamId]) {
         // TODO: Send error and close connection
         return;
       }
 
-      this.requestHandler.handle(frame);
+      this.requestFramesHandler(frame, this);
     } else {
-      const handler = this.registry.get(frame.streamId);
+      const handler = this.registry[frame.streamId];
       if (!handler) {
         // TODO: add validation
         return;
@@ -326,290 +109,82 @@ class GenericFrameHandler implements FlowControlledFrameHandler {
     // TODO: add extensions support
   }
 
-  close(error?: Error): void {
-    this.connectionHandler.close(error);
-    this.keepAliveSender?.close();
-  }
-}
-
-class ConnectionFrameHandler implements FrameHandler {
-  constructor(
-    private readonly multiplexere: ClientServerInputMultiplexerDemultiplexer,
-    private readonly keepAliveHandler: KeepAliveHandler,
-    private readonly rsocket: Partial<RSocket>
-  ) {}
-
-  handle(
-    frame:
-      | SetupFrame
-      | ResumeFrame
-      | ResumeOkFrame
-      | LeaseFrame
-      | KeepAliveFrame
-      | ErrorFrame
-      | MetadataPushFrame
+  handleConnectionFrames(
+    handler: (
+      frame:
+        | SetupFrame
+        | ResumeFrame
+        | ResumeOkFrame
+        | LeaseFrame
+        | KeepAliveFrame
+        | ErrorFrame
+        | MetadataPushFrame
+    ) => void
   ): void {
-    switch (frame.type) {
-      case FrameTypes.KEEPALIVE:
-        this.keepAliveHandler.handle(frame);
-        return;
-      case FrameTypes.LEASE:
-        // TODO: add lease handling
-        return;
-      case FrameTypes.ERROR:
-        // TODO: add code validation
-        this.multiplexere.close(new RSocketError(frame.code, frame.message));
-        return;
-      case FrameTypes.METADATA_PUSH:
-        if (this.rsocket.metadataPush) {
-          // this.rsocket.metadataPush()
-        }
-
-        return;
-      default:
-      // TODO: throw an exception and close connection
-    }
+    this.connectionFramesHandler = handler;
   }
 
-  close(error?: Error) {
-    this.keepAliveHandler.close();
-    this.rsocket.close?.call(this.rsocket, error);
-  }
-}
-
-class KeepAliveHandler implements FrameHandler {
-  private keepAliveLastReceivedMillis = Date.now();
-  private activeTimeout: any;
-
-  constructor(
-    private readonly multiplexer: ClientServerInputMultiplexerDemultiplexer,
-    private readonly outbound: Outbound,
-    private keepAliveTimeoutDuration: number
-  ) {
-    this.activeTimeout = setTimeout(
-      this.timeoutCheck.bind(this),
-      keepAliveTimeoutDuration
-    );
-  }
-
-  handle(frame: KeepAliveFrame): void {
-    this.keepAliveLastReceivedMillis = Date.now();
-    if (Flags.hasRespond(frame.flags)) {
-      this.outbound.send({
-        type: FrameTypes.KEEPALIVE,
-        streamId: 0,
-        data: frame.data,
-        flags: frame.flags ^ Flags.RESPOND,
-        lastReceivedPosition: 0,
-      });
-    }
-  }
-
-  close() {
-    clearTimeout(this.activeTimeout);
-  }
-
-  private timeoutCheck() {
-    const now = Date.now();
-    const noKeepAliveDuration = now - this.keepAliveLastReceivedMillis;
-    if (noKeepAliveDuration >= this.keepAliveTimeoutDuration) {
-      this.multiplexer.close(
-        new Error(
-          `No keep-alive acks for ${this.keepAliveTimeoutDuration} millis`
-        )
-      );
-    } else {
-      this.activeTimeout = setTimeout(
-        this.timeoutCheck.bind(this),
-        Math.max(100, this.keepAliveTimeoutDuration - noKeepAliveDuration)
-      );
-    }
-  }
-}
-
-class KeepAliveSender {
-  private activeInterval: any;
-
-  constructor(
-    private readonly outbound: Outbound,
-    keepAlivePeriodDuration: number
-  ) {
-    this.activeInterval = setInterval(
-      this.sendKeepAlive.bind(this),
-      keepAlivePeriodDuration
-    );
-  }
-
-  private sendKeepAlive() {
-    this.outbound.send({
-      type: FrameTypes.KEEPALIVE,
-      streamId: 0,
-      data: undefined,
-      flags: Flags.RESPOND,
-      lastReceivedPosition: 0,
-    });
-  }
-
-  close(): void {
-    clearInterval(this.activeInterval);
-  }
-}
-
-class SetupFrameHandler implements FlowControlledFrameHandler {
-  private done: boolean;
-  private error: Error | undefined;
-
-  constructor(
-    private readonly multiplexer: ClientServerInputMultiplexerDemultiplexer,
-    private readonly outbound: Outbound,
-    private readonly config: ServerConfig
-  ) {}
-
-  handle(
-    frame:
-      | SetupFrame
-      | ResumeFrame
-      | ResumeOkFrame
-      | LeaseFrame
-      | KeepAliveFrame
-      | ErrorFrame
-      | MetadataPushFrame,
-    callback?: (controlRequest: FlowControl) => void
+  handleStream(
+    handler: (
+      frame:
+        | RequestFnfFrame
+        | RequestResponseFrame
+        | RequestStreamFrame
+        | RequestChannelFrame,
+      stream: Outbound & Stream
+    ) => boolean
   ): void {
-    if (frame.type === FrameTypes.SETUP) {
-      this.config.acceptor
-        .accept(
-          {
-            data: frame.data,
-            dataMimeType: frame.dataMimeType,
-            metadata: frame.metadata,
-            metadataMimeType: frame.metadataMimeType,
-            flags: frame.flags,
-            keepAliveMaxLifetime: frame.lifetime,
-            keepAliveInterval: frame.keepAlive,
-            resumeToken: frame.resumeToken,
-          },
-          new RSocketRequester(this.multiplexer)
-        )
-        .then(
-          (responder) => {
-            if (this.done) {
-              responder.close?.call(responder, this.error);
-              return;
-            }
+    this.requestFramesHandler = handler;
+  }
 
-            this.multiplexer["delegateHandler"] = new GenericFrameHandler(
-              new RequestFrameHandler(
-                this.multiplexer,
-                this.outbound,
-                this.config.fragmentSize,
-                responder
-              ),
-              new ConnectionFrameHandler(
-                this.multiplexer,
-                new KeepAliveHandler(
-                  this.multiplexer,
-                  this.outbound,
-                  frame.lifetime
-                ),
-                responder
-              ),
-              this.multiplexer,
-              this.config.keepAlive.hasSender
-                ? new KeepAliveSender(this.outbound, frame.keepAlive)
-                : undefined
-            );
+  abstract send(frame: Frame): void;
 
-            callback(FlowControl.ALL);
-          },
-          (error) => this.multiplexer.close(error)
-        );
+  get connectionOutbound(): Outbound {
+    return this;
+  }
+
+  createStream(
+    stream: StreamFrameHandler & StreamLifecycleHandler,
+    streamType:
+      | FrameTypes.REQUEST_FNF
+      | FrameTypes.REQUEST_RESPONSE
+      | FrameTypes.REQUEST_STREAM
+      | FrameTypes.REQUEST_CHANNEL
+  ): void {
+    // handle requester side stream registration
+    if (this.done) {
+      stream.handleReject(new Error("Already closed"));
       return;
     }
-    // TODO: throw an exception and close connection
+
+    const registry = this.registry;
+    this.streamIdSupplier.next((streamId) => {
+      registry[streamId] = stream;
+
+      return stream.handleReady(streamId, this);
+    }, (Object.keys(registry) as any) as Array<number>);
+  }
+
+  add(handler: StreamFrameHandler): void {
+    this.registry[handler.streamId] = handler;
+  }
+
+  remove(stream: StreamFrameHandler): void {
+    delete this.registry[stream.streamId];
   }
 
   close(error?: Error): void {
-    this.done = true;
-    this.error = error;
-    // FIXME: send reject frame
-  }
-}
+    if (this.done) {
+      super.close(error);
+      return;
+    }
+    for (const streamId in this.registry) {
+      const stream = this.registry[streamId];
 
-export class RSocketRequester implements RSocket {
-  constructor(private multiplexer: ClientServerInputMultiplexerDemultiplexer) {}
-
-  fireAndForget(
-    payload: Payload,
-    responderStream: OnTerminalSubscriber
-  ): Cancellable {
-    return new RequestFnFRequesterHandler(
-      payload,
-      responderStream,
-      this.multiplexer
-    );
-  }
-
-  requestResponse(
-    payload: Payload,
-    responderStream: OnTerminalSubscriber &
-      OnNextSubscriber &
-      OnExtensionSubscriber
-  ): Cancellable & OnExtensionSubscriber {
-    return new RequestResponseRequesterStream(
-      payload,
-      responderStream,
-      this.multiplexer
-    );
-  }
-
-  requestStream(
-    payload: Payload,
-    initialRequestN: number,
-    responderStream: OnTerminalSubscriber &
-      OnNextSubscriber &
-      OnExtensionSubscriber
-  ): Requestable & OnExtensionSubscriber & Cancellable {
-    return new RequestStreamRequesterStream(
-      payload,
-      initialRequestN,
-      responderStream,
-      this.multiplexer
-    );
-  }
-
-  requestChannel(
-    payload: Payload,
-    initialRequestN: number,
-    isCompleted: boolean,
-    responderStream: OnTerminalSubscriber &
-      OnNextSubscriber &
-      OnExtensionSubscriber &
-      Requestable &
-      Cancellable
-  ): OnTerminalSubscriber &
-    OnNextSubscriber &
-    OnExtensionSubscriber &
-    Requestable &
-    Cancellable {
-    return new RequestChannelRequesterStream(
-      payload,
-      initialRequestN,
-      isCompleted,
-      responderStream,
-      this.multiplexer
-    );
-  }
-
-  metadataPush(metadata: Buffer, responderStream: OnTerminalSubscriber): void {
-    throw new Error("Method not implemented.");
-  }
-
-  close(error?: Error): void {
-    this.multiplexer.close();
-  }
-
-  onClose(callback): void {
-    this.multiplexer.onClose(callback);
+      stream.close(
+        new Error(`Closed. ${error ? `Original cause [${error}].` : ""}`)
+      );
+    }
+    super.close(error);
   }
 }

--- a/packages/rsocket-core/src/RSocket.ts
+++ b/packages/rsocket-core/src/RSocket.ts
@@ -1,12 +1,4 @@
 import { Closeable } from "./Common";
-import {
-  CancelFrame,
-  ErrorFrame,
-  ExtFrame,
-  PayloadFrame,
-  RequestNFrame,
-} from "./Frames";
-import { FrameHandler, Outbound } from "./Transport";
 
 /**
  * A single unit of data exchanged between the peers of a `RSocket`.
@@ -50,31 +42,6 @@ export interface OnNextSubscriber {
 export interface OnTerminalSubscriber {
   onError(error: Error): void;
   onComplete(): void;
-}
-
-export type StreamConfig = {
-  outbound: Outbound;
-  fragmentSize: number;
-};
-
-export interface StreamLifecycleHandler {
-  handleReady(streamId: number, config: StreamConfig): boolean;
-  handleReject(error: Error): void;
-}
-
-export interface StreamFrameHandler extends FrameHandler {
-  readonly streamId: number;
-  handle(
-    frame: PayloadFrame | ErrorFrame | CancelFrame | RequestNFrame | ExtFrame
-  ): void;
-  close(error?: Error): void;
-}
-
-export interface StreamsRegistry {
-  get(streamId: number): StreamFrameHandler;
-  add(handler: StreamFrameHandler, streamId: number): void;
-  add(handler: StreamFrameHandler & StreamLifecycleHandler): void;
-  remove(handler: StreamFrameHandler): void;
 }
 
 export interface SocketAcceptor {

--- a/packages/rsocket-core/src/RSocketConnector.ts
+++ b/packages/rsocket-core/src/RSocketConnector.ts
@@ -51,7 +51,7 @@ export class RSocketConnector {
   async connect(): Promise<RSocket> {
     const connection = await this.transport.connect();
     const keepAliveSender = new KeepAliveSender(
-      connection.multiplexer.connectionOutbound,
+      connection.connectionOutbound,
       this.setupFrame.keepAlive
     );
     const keepAliveHandler = new KeepAliveHandler(
@@ -70,13 +70,13 @@ export class RSocketConnector {
       keepAliveHandler.close();
       connectionFrameHandler.close(e);
     });
-    connection.demultiplexer.handleConnectionFrames(
+    connection.connectionInbound(
       connectionFrameHandler.handle.bind(connectionFrameHandler)
     );
-    connection.demultiplexer.handleStream(
+    connection.handleRequestStream(
       streamsHandler.handle.bind(connectionFrameHandler)
     );
-    connection.multiplexer.connectionOutbound.send(this.setupFrame);
+    connection.connectionOutbound.send(this.setupFrame);
     keepAliveHandler.start();
     keepAliveSender.start();
 

--- a/packages/rsocket-core/src/RSocketServer.ts
+++ b/packages/rsocket-core/src/RSocketServer.ts
@@ -54,7 +54,7 @@ export class RSocketServer {
             );
             const keepAliveSender = this.serverSideKeepAlive
               ? new KeepAliveSender(
-                  connection.multiplexer.connectionOutbound,
+                  connection.connectionOutbound,
                   frame.keepAlive
                 )
               : undefined;
@@ -70,10 +70,10 @@ export class RSocketServer {
               keepAliveHandler.close();
               connectionFrameHandler.close(e);
             });
-            connection.demultiplexer.handleConnectionFrames(
+            connection.connectionInbound(
               connectionFrameHandler.handle.bind(connectionFrameHandler)
             );
-            connection.demultiplexer.handleStream(
+            connection.handleRequestStream(
               streamsHandler.handle.bind(connectionFrameHandler)
             );
 

--- a/packages/rsocket-core/src/RSocketServer.ts
+++ b/packages/rsocket-core/src/RSocketServer.ts
@@ -1,11 +1,19 @@
-import { ClientServerInputMultiplexerDemultiplexer } from "./ClientServerMultiplexerDemultiplexer";
+import { ErrorCodes, FrameTypes, RSocketError } from ".";
 import { Closeable } from "./Common";
 import { SocketAcceptor } from "./RSocket";
+import {
+  ConnectionFrameHandler,
+  KeepAliveHandler,
+  KeepAliveSender,
+  RSocketRequester,
+  StreamHandler,
+} from "./RSocketSupport";
 import { ServerTransport } from "./Transport";
 
 export type ServerConfig = {
   transport: ServerTransport;
   acceptor: SocketAcceptor;
+  serverSideKeepAlive?: boolean;
   lease?: {};
   resume?: {};
 };
@@ -13,22 +21,77 @@ export type ServerConfig = {
 export class RSocketServer {
   private transport: ServerTransport;
   private acceptor: SocketAcceptor;
+  private serverSideKeepAlive: boolean;
 
   constructor(config: ServerConfig) {
     this.acceptor = config.acceptor;
     this.transport = config.transport;
+    this.serverSideKeepAlive = config.serverSideKeepAlive;
   }
 
   async bind(): Promise<Closeable> {
-    return await this.transport.bind((connection) => {
-      new ClientServerInputMultiplexerDemultiplexer(connection, {
-        fragmentSize: 0,
-        keepAlive: {
-          hasSender: false,
-        },
-        streamIdSupplier: () => 2,
-        acceptor: this.acceptor,
-      });
+    return await this.transport.bind(async (frame, connection) => {
+      switch (frame.type) {
+        case FrameTypes.SETUP: {
+          try {
+            const requester = new RSocketRequester(connection, 0);
+            const responder = await this.acceptor.accept(
+              {
+                data: frame.data,
+                dataMimeType: frame.dataMimeType,
+                metadata: frame.metadata,
+                metadataMimeType: frame.metadataMimeType,
+                flags: frame.flags,
+                keepAliveMaxLifetime: frame.lifetime,
+                keepAliveInterval: frame.keepAlive,
+                resumeToken: frame.resumeToken,
+              },
+              requester
+            );
+            const keepAliveHandler = new KeepAliveHandler(
+              connection,
+              frame.lifetime
+            );
+            const keepAliveSender = this.serverSideKeepAlive
+              ? new KeepAliveSender(
+                  connection.multiplexer.connectionOutbound,
+                  frame.keepAlive
+                )
+              : undefined;
+            const connectionFrameHandler = new ConnectionFrameHandler(
+              connection,
+              keepAliveHandler,
+              responder
+            );
+            const streamsHandler = new StreamHandler(responder, 0);
+
+            connection.onClose((e) => {
+              keepAliveSender?.close();
+              keepAliveHandler.close();
+              connectionFrameHandler.close(e);
+            });
+            connection.demultiplexer.handleConnectionFrames(
+              connectionFrameHandler.handle.bind(connectionFrameHandler)
+            );
+            connection.demultiplexer.handleStream(
+              streamsHandler.handle.bind(connectionFrameHandler)
+            );
+
+            keepAliveHandler.start();
+            keepAliveSender?.start();
+          } catch (e) {
+            connection.close(
+              e instanceof RSocketError
+                ? e
+                : new RSocketError(ErrorCodes.REJECTED_SETUP, e.message)
+            );
+          }
+          return;
+        }
+        default: {
+          connection.close(new RSocketError(ErrorCodes.UNSUPPORTED_SETUP));
+        }
+      }
     });
   }
 }

--- a/packages/rsocket-core/src/RSocketSupport.ts
+++ b/packages/rsocket-core/src/RSocketSupport.ts
@@ -57,7 +57,7 @@ export class RSocketRequester implements RSocket {
       this.fragmentSize
     );
 
-    this.connection.multiplexer.createStream(handler, FrameTypes.REQUEST_FNF);
+    this.connection.createRequestStream(handler, FrameTypes.REQUEST_FNF);
 
     return handler;
   }
@@ -74,10 +74,7 @@ export class RSocketRequester implements RSocket {
       this.fragmentSize
     );
 
-    this.connection.multiplexer.createStream(
-      handler,
-      FrameTypes.REQUEST_RESPONSE
-    );
+    this.connection.createRequestStream(handler, FrameTypes.REQUEST_RESPONSE);
 
     return handler;
   }
@@ -96,10 +93,7 @@ export class RSocketRequester implements RSocket {
       initialRequestN
     );
 
-    this.connection.multiplexer.createStream(
-      handler,
-      FrameTypes.REQUEST_STREAM
-    );
+    this.connection.createRequestStream(handler, FrameTypes.REQUEST_STREAM);
 
     return handler;
   }
@@ -126,10 +120,7 @@ export class RSocketRequester implements RSocket {
       initialRequestN
     );
 
-    this.connection.multiplexer.createStream(
-      handler,
-      FrameTypes.REQUEST_STREAM
-    );
+    this.connection.createRequestStream(handler, FrameTypes.REQUEST_CHANNEL);
 
     return handler;
   }
@@ -288,7 +279,7 @@ export class KeepAliveHandler implements FrameHandler {
     private readonly connection: DuplexConnection,
     private readonly keepAliveTimeoutDuration: number
   ) {
-    this.outbound = connection.multiplexer.connectionOutbound;
+    this.outbound = connection.connectionOutbound;
   }
 
   handle(frame: KeepAliveFrame): void {

--- a/packages/rsocket-core/src/RSocketSupport.ts
+++ b/packages/rsocket-core/src/RSocketSupport.ts
@@ -1,0 +1,395 @@
+import { ErrorCodes, RSocketError } from "./Errors";
+import {
+  ErrorFrame,
+  Flags,
+  FrameTypes,
+  KeepAliveFrame,
+  LeaseFrame,
+  MetadataPushFrame,
+  RequestChannelFrame,
+  RequestFnfFrame,
+  RequestResponseFrame,
+  RequestStreamFrame,
+  ResumeFrame,
+  ResumeOkFrame,
+  SetupFrame,
+} from "./Frames";
+import {
+  RequestChannelRequesterStream,
+  RequestChannelResponderStream,
+} from "./RequestChannelStream";
+import {
+  RequestFnFRequesterHandler,
+  RequestFnfResponderHandler,
+} from "./RequestFnFStream";
+import {
+  RequestResponseRequesterStream,
+  RequestResponseResponderStream,
+} from "./RequestResponseStream";
+import {
+  RequestStreamRequesterStream,
+  RequestStreamResponderStream,
+} from "./RequestStreamStream";
+import {
+  Cancellable,
+  OnExtensionSubscriber,
+  OnNextSubscriber,
+  OnTerminalSubscriber,
+  Payload,
+  Requestable,
+  RSocket,
+} from "./RSocket";
+import { DuplexConnection, FrameHandler, Outbound, Stream } from "./Transport";
+
+export class RSocketRequester implements RSocket {
+  constructor(
+    private readonly connection: DuplexConnection,
+    private readonly fragmentSize: number
+  ) {}
+
+  fireAndForget(
+    payload: Payload,
+    responderStream: OnTerminalSubscriber
+  ): Cancellable {
+    const handler = new RequestFnFRequesterHandler(
+      payload,
+      responderStream,
+      this.fragmentSize
+    );
+
+    this.connection.multiplexer.createStream(handler, FrameTypes.REQUEST_FNF);
+
+    return handler;
+  }
+
+  requestResponse(
+    payload: Payload,
+    responderStream: OnTerminalSubscriber &
+      OnNextSubscriber &
+      OnExtensionSubscriber
+  ): Cancellable & OnExtensionSubscriber {
+    const handler = new RequestResponseRequesterStream(
+      payload,
+      responderStream,
+      this.fragmentSize
+    );
+
+    this.connection.multiplexer.createStream(
+      handler,
+      FrameTypes.REQUEST_RESPONSE
+    );
+
+    return handler;
+  }
+
+  requestStream(
+    payload: Payload,
+    initialRequestN: number,
+    responderStream: OnTerminalSubscriber &
+      OnNextSubscriber &
+      OnExtensionSubscriber
+  ): Requestable & OnExtensionSubscriber & Cancellable {
+    const handler = new RequestStreamRequesterStream(
+      payload,
+      responderStream,
+      this.fragmentSize,
+      initialRequestN
+    );
+
+    this.connection.multiplexer.createStream(
+      handler,
+      FrameTypes.REQUEST_STREAM
+    );
+
+    return handler;
+  }
+
+  requestChannel(
+    payload: Payload,
+    initialRequestN: number,
+    isCompleted: boolean,
+    responderStream: OnTerminalSubscriber &
+      OnNextSubscriber &
+      OnExtensionSubscriber &
+      Requestable &
+      Cancellable
+  ): OnTerminalSubscriber &
+    OnNextSubscriber &
+    OnExtensionSubscriber &
+    Requestable &
+    Cancellable {
+    const handler = new RequestChannelRequesterStream(
+      payload,
+      isCompleted,
+      responderStream,
+      this.fragmentSize,
+      initialRequestN
+    );
+
+    this.connection.multiplexer.createStream(
+      handler,
+      FrameTypes.REQUEST_STREAM
+    );
+
+    return handler;
+  }
+
+  metadataPush(metadata: Buffer, responderStream: OnTerminalSubscriber): void {
+    throw new Error("Method not implemented.");
+  }
+
+  close(error?: Error): void {
+    this.connection.close(error);
+  }
+
+  onClose(callback): void {
+    this.connection.onClose(callback);
+  }
+}
+
+export class StreamHandler {
+  constructor(
+    private rsocket: Partial<RSocket>,
+    private fragmentSize: number
+  ) {}
+
+  handle(
+    frame:
+      | RequestFnfFrame
+      | RequestResponseFrame
+      | RequestStreamFrame
+      | RequestChannelFrame,
+    stream: Outbound & Stream
+  ): void {
+    switch (frame.type) {
+      case FrameTypes.REQUEST_FNF:
+        if (this.rsocket.fireAndForget) {
+          new RequestFnfResponderHandler(
+            frame.streamId,
+            stream,
+            this.rsocket.fireAndForget.bind(this.rsocket),
+            frame
+          );
+        }
+        return;
+      case FrameTypes.REQUEST_RESPONSE:
+        if (this.rsocket.requestResponse) {
+          new RequestResponseResponderStream(
+            frame.streamId,
+            stream,
+            this.fragmentSize,
+            this.rsocket.requestResponse.bind(this.rsocket),
+            frame
+          );
+          return;
+        }
+
+        this.rejectRequest(frame.streamId, stream);
+
+        return;
+
+      case FrameTypes.REQUEST_STREAM:
+        if (this.rsocket.requestStream) {
+          new RequestStreamResponderStream(
+            frame.streamId,
+            stream,
+            this.fragmentSize,
+            this.rsocket.requestStream.bind(this.rsocket),
+            frame
+          );
+          return;
+        }
+
+        this.rejectRequest(frame.streamId, stream);
+
+        return;
+
+      case FrameTypes.REQUEST_CHANNEL:
+        if (this.rsocket.requestChannel) {
+          new RequestChannelResponderStream(
+            frame.streamId,
+            stream,
+            this.fragmentSize,
+            this.rsocket.requestChannel.bind(this.rsocket),
+            frame
+          );
+          return;
+        }
+
+        this.rejectRequest(frame.streamId, stream);
+
+        return;
+    }
+  }
+
+  rejectRequest(streamId: number, stream: Stream) {
+    stream.send({
+      type: FrameTypes.ERROR,
+      streamId,
+      flags: Flags.NONE,
+      code: ErrorCodes.REJECTED,
+      message: "No available handler found",
+    });
+  }
+}
+
+export class ConnectionFrameHandler implements FrameHandler {
+  constructor(
+    private readonly connection: DuplexConnection,
+    private readonly keepAliveHandler: KeepAliveHandler,
+    private readonly rsocket: Partial<RSocket>
+  ) {}
+
+  handle(
+    frame:
+      | SetupFrame
+      | ResumeFrame
+      | ResumeOkFrame
+      | LeaseFrame
+      | KeepAliveFrame
+      | ErrorFrame
+      | MetadataPushFrame
+  ): void {
+    switch (frame.type) {
+      case FrameTypes.KEEPALIVE:
+        this.keepAliveHandler.handle(frame);
+        return;
+      case FrameTypes.LEASE:
+        // TODO: add lease handling
+        return;
+      case FrameTypes.ERROR:
+        // TODO: add code validation
+        this.connection.close(new RSocketError(frame.code, frame.message));
+        return;
+      case FrameTypes.METADATA_PUSH:
+        if (this.rsocket.metadataPush) {
+          // this.rsocket.metadataPush()
+        }
+
+        return;
+      default:
+      // TODO: throw an exception and close connection
+    }
+  }
+
+  close(error?: Error) {
+    this.keepAliveHandler.close();
+    this.rsocket.close?.call(this.rsocket, error);
+  }
+}
+
+export class KeepAliveHandler implements FrameHandler {
+  private readonly outbound: Outbound;
+  private keepAliveLastReceivedMillis: number;
+  private activeTimeout: any;
+  private state: number;
+
+  constructor(
+    private readonly connection: DuplexConnection,
+    private readonly keepAliveTimeoutDuration: number
+  ) {
+    this.outbound = connection.multiplexer.connectionOutbound;
+  }
+
+  handle(frame: KeepAliveFrame): void {
+    this.keepAliveLastReceivedMillis = Date.now();
+    if (Flags.hasRespond(frame.flags)) {
+      this.outbound.send({
+        type: FrameTypes.KEEPALIVE,
+        streamId: 0,
+        data: frame.data,
+        flags: frame.flags ^ Flags.RESPOND,
+        lastReceivedPosition: 0,
+      });
+    }
+  }
+
+  start() {
+    if (this.state !== 0) {
+      return;
+    }
+
+    this.keepAliveLastReceivedMillis = Date.now();
+    this.state = 1;
+    this.activeTimeout = setTimeout(
+      this.timeoutCheck.bind(this),
+      this.keepAliveTimeoutDuration
+    );
+  }
+
+  pause() {
+    if (this.state !== 1) {
+      return;
+    }
+
+    this.state = 0;
+    clearTimeout(this.activeTimeout);
+  }
+
+  close() {
+    this.state = 2;
+    clearTimeout(this.activeTimeout);
+  }
+
+  private timeoutCheck() {
+    const now = Date.now();
+    const noKeepAliveDuration = now - this.keepAliveLastReceivedMillis;
+    if (noKeepAliveDuration >= this.keepAliveTimeoutDuration) {
+      this.connection.close(
+        new Error(
+          `No keep-alive acks for ${this.keepAliveTimeoutDuration} millis`
+        )
+      );
+    } else {
+      this.activeTimeout = setTimeout(
+        this.timeoutCheck.bind(this),
+        Math.max(100, this.keepAliveTimeoutDuration - noKeepAliveDuration)
+      );
+    }
+  }
+}
+
+export class KeepAliveSender {
+  private activeInterval: any;
+  private state: number;
+
+  constructor(
+    private readonly outbound: Outbound,
+    private readonly keepAlivePeriodDuration: number
+  ) {}
+
+  private sendKeepAlive() {
+    this.outbound.send({
+      type: FrameTypes.KEEPALIVE,
+      streamId: 0,
+      data: undefined,
+      flags: Flags.RESPOND,
+      lastReceivedPosition: 0,
+    });
+  }
+
+  start() {
+    if (this.state !== 0) {
+      return;
+    }
+
+    this.state = 1;
+    this.activeInterval = setInterval(
+      this.sendKeepAlive.bind(this),
+      this.keepAlivePeriodDuration
+    );
+  }
+
+  pause() {
+    if (this.state !== 1) {
+      return;
+    }
+    this.state = 0;
+    clearInterval(this.activeInterval);
+  }
+
+  close(): void {
+    this.state = 2;
+    clearInterval(this.activeInterval);
+  }
+}

--- a/packages/rsocket-core/src/RequestStreamStream.ts
+++ b/packages/rsocket-core/src/RequestStreamStream.ts
@@ -18,12 +18,12 @@ import {
   OnTerminalSubscriber,
   Payload,
   Requestable,
-  StreamConfig,
+} from "./RSocket";
+import {
+  Stream,
   StreamFrameHandler,
   StreamLifecycleHandler,
-  StreamsRegistry,
-} from "./RSocket";
-import { Outbound } from "./Transport";
+} from "./Transport";
 
 export class RequestStreamRequesterStream
   implements
@@ -34,7 +34,7 @@ export class RequestStreamRequesterStream
     StreamLifecycleHandler,
     Reassembler.FragmentsHolder {
   private done: boolean;
-  private outbound: Outbound;
+  private stream: Stream;
 
   private hasExtension: boolean;
   private extendedType: number;
@@ -48,37 +48,38 @@ export class RequestStreamRequesterStream
   streamId: number;
 
   constructor(
-    private payload: Payload,
-    private initialRequestN: number,
-    private receiver: OnTerminalSubscriber &
+    private readonly payload: Payload,
+    private readonly receiver: OnTerminalSubscriber &
       OnNextSubscriber &
       OnExtensionSubscriber,
-    private streamsRegistry: StreamsRegistry
+    private readonly fragmentSize: number,
+    private initialRequestN: number
   ) {
     // TODO: add payload size validation
-    streamsRegistry.add(this);
   }
 
-  handleReady(streamId: number, { outbound, fragmentSize }: StreamConfig) {
+  handleReady(streamId: number, stream: Stream) {
     if (this.done) {
       return false;
     }
 
     this.streamId = streamId;
-    this.outbound = outbound;
+    this.stream = stream;
 
-    if (isFragmentable(this.payload, fragmentSize, FrameTypes.REQUEST_STREAM)) {
+    if (
+      isFragmentable(this.payload, this.fragmentSize, FrameTypes.REQUEST_STREAM)
+    ) {
       for (const frame of fragmentWithRequestN(
         streamId,
         this.payload,
-        fragmentSize,
+        this.fragmentSize,
         FrameTypes.REQUEST_STREAM,
         this.initialRequestN
       )) {
-        this.outbound.send(frame);
+        this.stream.send(frame);
       }
     } else {
-      this.outbound.send({
+      this.stream.send({
         type: FrameTypes.REQUEST_STREAM,
         data: this.payload.data,
         metadata: this.payload.metadata,
@@ -89,7 +90,7 @@ export class RequestStreamRequesterStream
     }
 
     if (this.hasExtension) {
-      this.outbound.send({
+      this.stream.send({
         type: FrameTypes.EXT,
         streamId,
         extendedContent: this.extendedContent,
@@ -123,7 +124,7 @@ export class RequestStreamRequesterStream
           if (hasComplete) {
             this.done = true;
 
-            this.streamsRegistry.remove(this);
+            this.stream.remove(this);
 
             if (!hasNext) {
               // TODO: add validation no frame in reassembly
@@ -150,7 +151,7 @@ export class RequestStreamRequesterStream
       case FrameTypes.ERROR: {
         this.done = true;
 
-        this.streamsRegistry.remove(this);
+        this.stream.remove(this);
 
         Reassembler.cancel(this);
 
@@ -168,13 +169,13 @@ export class RequestStreamRequesterStream
       }
 
       default: {
-        this.streamsRegistry.remove(this);
+        this.stream.remove(this);
 
         this.close(
           new RSocketError(ErrorCodes.CANCELED, "Received unexpected frame")
         );
 
-        this.outbound.send({
+        this.stream.send({
           type: FrameTypes.CANCEL,
           streamId: this.streamId,
           flags: Flags.NONE,
@@ -195,7 +196,7 @@ export class RequestStreamRequesterStream
       return;
     }
 
-    this.outbound.send({
+    this.stream.send({
       type: FrameTypes.REQUEST_N,
       flags: Flags.NONE,
       requestN: n,
@@ -210,13 +211,12 @@ export class RequestStreamRequesterStream
 
     this.done = true;
 
-    this.streamsRegistry.remove(this);
-
     if (!this.streamId) {
       return;
     }
 
-    this.outbound.send({
+    this.stream.remove(this);
+    this.stream.send({
       type: FrameTypes.CANCEL,
       flags: Flags.NONE,
       streamId: this.streamId,
@@ -242,7 +242,7 @@ export class RequestStreamRequesterStream
       return;
     }
 
-    this.outbound.send({
+    this.stream.send({
       streamId: this.streamId,
       type: FrameTypes.EXT,
       extendedType,
@@ -285,10 +285,9 @@ export class RequestStreamResponderStream
 
   constructor(
     readonly streamId: number,
-    private registry: StreamsRegistry,
-    private outbound: Outbound,
-    private fragmentSize: number,
-    private handler: (
+    private readonly stream: Stream,
+    private readonly fragmentSize: number,
+    private readonly handler: (
       payload: Payload,
       initialRequestN: number,
       senderStream: OnTerminalSubscriber &
@@ -297,7 +296,7 @@ export class RequestStreamResponderStream
     ) => Cancellable & Requestable & OnExtensionSubscriber,
     frame: RequestStreamFrame
   ) {
-    registry.add(this, streamId);
+    stream.add(this);
 
     if (Flags.hasFollows(frame.flags)) {
       this.initialRequestN = frame.requestN;
@@ -344,14 +343,14 @@ export class RequestStreamResponderStream
 
     this.done = true;
 
-    this.registry.remove(this);
+    this.stream.remove(this);
 
     Reassembler.cancel(this);
 
     this.receiver?.cancel();
 
     if (frame.type !== FrameTypes.CANCEL && frame.type !== FrameTypes.ERROR) {
-      this.outbound.send({
+      this.stream.send({
         type: FrameTypes.ERROR,
         flags: Flags.NONE,
         code: ErrorCodes.CANCELED,
@@ -374,9 +373,9 @@ export class RequestStreamResponderStream
 
     this.done = true;
 
-    this.registry.remove(this);
+    this.stream.remove(this);
 
-    this.outbound.send({
+    this.stream.send({
       type: FrameTypes.ERROR,
       flags: Flags.NONE,
       code:
@@ -396,7 +395,7 @@ export class RequestStreamResponderStream
     if (isCompletion) {
       this.done = true;
 
-      this.registry.remove(this);
+      this.stream.remove(this);
     }
 
     // TODO: add payload size validation
@@ -409,10 +408,10 @@ export class RequestStreamResponderStream
         FrameTypes.PAYLOAD,
         isCompletion
       )) {
-        this.outbound.send(frame);
+        this.stream.send(frame);
       }
     } else {
-      this.outbound.send({
+      this.stream.send({
         type: FrameTypes.PAYLOAD,
         flags:
           Flags.NEXT |
@@ -432,9 +431,9 @@ export class RequestStreamResponderStream
 
     this.done = true;
 
-    this.registry.remove(this);
+    this.stream.remove(this);
 
-    this.outbound.send({
+    this.stream.send({
       type: FrameTypes.PAYLOAD,
       flags: Flags.COMPLETE,
       streamId: this.streamId,
@@ -452,7 +451,7 @@ export class RequestStreamResponderStream
       return;
     }
 
-    this.outbound.send({
+    this.stream.send({
       type: FrameTypes.EXT,
       streamId: this.streamId,
       flags: canBeIgnored ? Flags.IGNORE : Flags.NONE,

--- a/packages/rsocket-core/src/RequestStreamStream.ts
+++ b/packages/rsocket-core/src/RequestStreamStream.ts
@@ -275,9 +275,9 @@ export class RequestStreamResponderStream
     OnExtensionSubscriber,
     StreamFrameHandler,
     Reassembler.FragmentsHolder {
+  private readonly initialRequestN: number;
   private receiver?: Cancellable & Requestable & OnExtensionSubscriber;
   private done: boolean;
-  private initialRequestN: number;
 
   hasFragments: boolean;
   data: Buffer;

--- a/packages/rsocket-core/src/index.ts
+++ b/packages/rsocket-core/src/index.ts
@@ -23,3 +23,4 @@ export * from "./RSocket";
 export * from "./RSocketConnector";
 export * from "./RSocketServer";
 export * from "./Transport";
+export * from "./ClientServerMultiplexerDemultiplexer";

--- a/packages/rsocket-examples/src/ClientServerRequestResponseExampleTcp.ts
+++ b/packages/rsocket-examples/src/ClientServerRequestResponseExampleTcp.ts
@@ -3,6 +3,7 @@ import {
   OnNextSubscriber,
   OnTerminalSubscriber,
   Payload,
+  RSocket,
   RSocketConnector,
   RSocketServer,
 } from "@rsocket/rsocket-core";
@@ -64,7 +65,7 @@ function makeConnector() {
   });
 }
 
-async function requestResponse(rsocket) {
+async function requestResponse(rsocket: RSocket) {
   return new Promise((resolve, reject) => {
     return rsocket.requestResponse(
       {

--- a/packages/rsocket-tcp-client/src/TcpDuplexConnection.ts
+++ b/packages/rsocket-tcp-client/src/TcpDuplexConnection.ts
@@ -1,10 +1,8 @@
 import {
   ClientServerInputMultiplexerDemultiplexer,
-  Demultiplexer,
   Deserializer,
   DuplexConnection,
   Frame,
-  Multiplexer,
   serializeFrameWithLength,
   StreamIdGenerator,
 } from "@rsocket/rsocket-core";
@@ -39,14 +37,6 @@ export class TcpDuplexConnection
      * socket.setEncoding(). The data will be lost if there is no listener when a Socket emits a 'data' event.
      */
     socket.on("data", this.handleData.bind(this));
-  }
-
-  get multiplexer(): Multiplexer {
-    return this;
-  }
-
-  get demultiplexer(): Demultiplexer {
-    return this;
   }
 
   get availability(): number {

--- a/packages/rsocket-tcp-client/src/__tests__/__snapshots__/TcpDuplexConnection.spec.ts.snap
+++ b/packages/rsocket-tcp-client/src/__tests__/__snapshots__/TcpDuplexConnection.spec.ts.snap
@@ -68,7 +68,7 @@ Array [
     },
     "flags": 32,
     "metadata": null,
-    "streamId": 0,
+    "streamId": 1,
     "type": 10,
   },
 ]
@@ -97,7 +97,7 @@ Array [
     },
     "flags": 32,
     "metadata": null,
-    "streamId": 0,
+    "streamId": 1,
     "type": 10,
   },
 ]

--- a/packages/rsocket-tcp-server/src/TcpDuplexConnection.ts
+++ b/packages/rsocket-tcp-server/src/TcpDuplexConnection.ts
@@ -1,10 +1,8 @@
 import {
   ClientServerInputMultiplexerDemultiplexer,
-  Demultiplexer,
   deserializeFrames,
   DuplexConnection,
   Frame,
-  Multiplexer,
   serializeFrameWithLength,
   StreamIdGenerator,
 } from "@rsocket/rsocket-core";
@@ -28,14 +26,6 @@ export class TcpDuplexConnection
     socket.on("close", this.handleClosed.bind(this));
     socket.on("error", this.handleError.bind(this));
     socket.once("data", this.handleFirst.bind(this));
-  }
-
-  get multiplexer(): Multiplexer {
-    return this;
-  }
-
-  get demultiplexer(): Demultiplexer {
-    return this;
   }
 
   get availability(): number {

--- a/packages/rsocket-tcp-server/src/TcpServerTransport.ts
+++ b/packages/rsocket-tcp-server/src/TcpServerTransport.ts
@@ -2,6 +2,7 @@ import {
   Closeable,
   Deferred,
   DuplexConnection,
+  Frame,
   ServerTransport,
 } from "@rsocket/rsocket-core";
 import net from "net";
@@ -30,7 +31,10 @@ export class TcpServerTransport implements ServerTransport {
   }
 
   bind(
-    connectionAcceptor: (connection: DuplexConnection) => void
+    connectionAcceptor: (
+      frame: Frame,
+      connection: DuplexConnection
+    ) => Promise<void>
   ): Promise<Closeable> {
     return new Promise((resolve, reject) => {
       const socketServer = this.serverCreator(this.serverOptions);
@@ -44,7 +48,7 @@ export class TcpServerTransport implements ServerTransport {
       socketServer.addListener("listening", () => {
         const serverCloseable = new ServerCloseable(socketServer);
         const connectionListener = (socket: net.Socket) => {
-          connectionAcceptor(new TcpDuplexConnection(socket));
+          new TcpDuplexConnection(socket, connectionAcceptor);
         };
         const closeListener = (error?: Error) => {
           serverCloseable.close(error);

--- a/packages/rsocket-websocket-client/src/WebsocketClientTransport.ts
+++ b/packages/rsocket-websocket-client/src/WebsocketClientTransport.ts
@@ -3,8 +3,8 @@ import {
   Deserializer,
   DuplexConnection,
 } from "@rsocket/rsocket-core";
-import { WebsocketDuplexConnection } from "./WebsocketDuplexConnection";
 import WebSocket, { ErrorEvent } from "ws";
+import { WebsocketDuplexConnection } from "./WebsocketDuplexConnection";
 
 export type ClientOptions = {
   url: string;

--- a/packages/rsocket-websocket-client/src/WebsocketDuplexConnection.ts
+++ b/packages/rsocket-websocket-client/src/WebsocketDuplexConnection.ts
@@ -1,10 +1,8 @@
 import {
   ClientServerInputMultiplexerDemultiplexer,
-  Demultiplexer,
   Deserializer,
   DuplexConnection,
   Frame,
-  Multiplexer,
   serializeFrame,
   StreamIdGenerator,
 } from "@rsocket/rsocket-core";
@@ -22,14 +20,6 @@ export class WebsocketDuplexConnection
     websocket.addEventListener("close", this.handleClosed.bind(this));
     websocket.addEventListener("error", this.handleError.bind(this));
     websocket.addEventListener("message", this.handleMessage.bind(this));
-  }
-
-  get multiplexer(): Multiplexer {
-    return this;
-  }
-
-  get demultiplexer(): Demultiplexer {
-    return this;
   }
 
   get availability(): number {

--- a/packages/rsocket-websocket-client/src/WebsocketDuplexConnection.ts
+++ b/packages/rsocket-websocket-client/src/WebsocketDuplexConnection.ts
@@ -1,39 +1,39 @@
 import {
-  Deferred,
+  ClientServerInputMultiplexerDemultiplexer,
+  Demultiplexer,
   Deserializer,
   DuplexConnection,
-  FlowControlledFrameHandler,
   Frame,
+  Multiplexer,
   serializeFrame,
+  StreamIdGenerator,
 } from "@rsocket/rsocket-core";
-import WebSocket, { ErrorEvent, CloseEvent } from "ws";
+import WebSocket, { CloseEvent, ErrorEvent } from "ws";
 
 export class WebsocketDuplexConnection
-  extends Deferred
+  extends ClientServerInputMultiplexerDemultiplexer
   implements DuplexConnection {
-  private handler: FlowControlledFrameHandler;
-
   constructor(
     private websocket: WebSocket,
     private deserializer: Deserializer
   ) {
-    super();
+    super(StreamIdGenerator.create(-1));
 
     websocket.addEventListener("close", this.handleClosed.bind(this));
     websocket.addEventListener("error", this.handleError.bind(this));
     websocket.addEventListener("message", this.handleMessage.bind(this));
   }
 
-  handle(handler: FlowControlledFrameHandler): void {
-    if (this.handler) {
-      throw new Error("Handle has already been installed");
-    }
+  get multiplexer(): Multiplexer {
+    return this;
+  }
 
-    this.handler = handler;
+  get demultiplexer(): Demultiplexer {
+    return this;
   }
 
   get availability(): number {
-    throw new Error("Method not implemented.");
+    return this.done ? 0 : 1;
   }
 
   close(error?: Error) {
@@ -83,7 +83,7 @@ export class WebsocketDuplexConnection
       const buffer = Buffer.from(message.data);
       const frame = this.deserializer.deserializeFrame(buffer);
 
-      this.handler.handle(frame);
+      this.handle(frame);
     } catch (error) {
       this.close(error);
     }

--- a/packages/rsocket-websocket-client/src/__tests__/__snapshots__/WebsocketDuplexConnection.spec.ts.snap
+++ b/packages/rsocket-websocket-client/src/__tests__/__snapshots__/WebsocketDuplexConnection.spec.ts.snap
@@ -1,3 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WebsocketDuplexConnection when receiving data when buffer contains a single frame deserializes received frames and calls the configured handler 1`] = `undefined`;
+exports[`WebsocketDuplexConnection when receiving data when buffer contains a single frame deserializes received frames and calls the configured handler 1`] = `
+Object {
+  "data": Object {
+    "data": Array [
+      104,
+      101,
+      108,
+      108,
+      111,
+      32,
+      119,
+      111,
+      114,
+      108,
+      100,
+    ],
+    "type": "Buffer",
+  },
+  "dataMimeType": "application/octet-stream",
+  "flags": 256,
+  "keepAlive": 60000,
+  "lifetime": 300000,
+  "majorVersion": 1,
+  "metadata": Object {
+    "data": Array [
+      104,
+      101,
+      108,
+      108,
+      111,
+      32,
+      119,
+      111,
+      114,
+      108,
+      100,
+    ],
+    "type": "Buffer",
+  },
+  "metadataMimeType": "application/octet-stream",
+  "minorVersion": 0,
+  "resumeToken": null,
+  "streamId": 0,
+  "type": 1,
+}
+`;

--- a/packages/rsocket-websocket-server/src/WebsocketDuplexConnection.ts
+++ b/packages/rsocket-websocket-server/src/WebsocketDuplexConnection.ts
@@ -1,10 +1,8 @@
 import {
   ClientServerInputMultiplexerDemultiplexer,
-  Demultiplexer,
   deserializeFrame,
   DuplexConnection,
   Frame,
-  Multiplexer,
   serializeFrame,
   StreamIdGenerator,
 } from "@rsocket/rsocket-core";
@@ -25,14 +23,6 @@ export class WebsocketDuplexConnection
     websocketDuplex.on("close", this.handleClosed.bind(this));
     websocketDuplex.on("error", this.handleError.bind(this));
     websocketDuplex.once("data", this.handleFirst.bind(this));
-  }
-
-  get multiplexer(): Multiplexer {
-    return this;
-  }
-
-  get demultiplexer(): Demultiplexer {
-    return this;
   }
 
   get availability(): number {

--- a/packages/rsocket-websocket-server/src/WebsocketServerTransport.ts
+++ b/packages/rsocket-websocket-server/src/WebsocketServerTransport.ts
@@ -2,6 +2,7 @@ import {
   Closeable,
   Deferred,
   DuplexConnection,
+  Frame,
   ServerTransport,
 } from "@rsocket/rsocket-core";
 import WebSocket, { Server } from "ws";
@@ -38,7 +39,10 @@ export class WebsocketServerTransport implements ServerTransport {
   }
 
   async bind(
-    connectionAcceptor: (connection: DuplexConnection) => void
+    connectionAcceptor: (
+      frame: Frame,
+      connection: DuplexConnection
+    ) => Promise<void>
   ): Promise<Closeable> {
     const websocketServer: Server = await this.connectServer();
     const serverCloseable = new ServerCloseable(websocketServer);
@@ -46,7 +50,7 @@ export class WebsocketServerTransport implements ServerTransport {
     const connectionListener = (websocket: WebSocket) => {
       websocket.binaryType = "nodebuffer";
       const duplex = WebSocket.createWebSocketStream(websocket);
-      connectionAcceptor(new WebsocketDuplexConnection(duplex));
+      new WebsocketDuplexConnection(duplex, connectionAcceptor);
     };
 
     const closeListener = (error?: Error) => {


### PR DESCRIPTION
This PR reworks responsibilities of the DuplexConnection to ensure that in the future it exposes required functionality. The main goal of these changes is to make sure we can access upcoming QUIC/WebTransport multiplexing/demultiplexing capabilities exposed on the low-level connection API (see the following [example](https://www.w3.org/TR/webtransport/#example-sending-stream)).

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>
Signed-off-by: Oleh Dokuka <oleh.dokuka@icloud.com>