### PR TITLE
fix: default WebSocket reference in rsocket-websocket-client to global browser reference

### DIFF
--- a/packages/rsocket-websocket-client/package.json
+++ b/packages/rsocket-websocket-client/package.json
@@ -17,7 +17,6 @@
     "@rsocket/rsocket-core": "^1.0.0"
   },
   "devDependencies": {
-    "@types/ws": "^7.4.7",
     "rimraf": "~3.0.2",
     "typescript": "~4.3.0"
   }

--- a/packages/rsocket-websocket-client/src/WebsocketClientTransport.ts
+++ b/packages/rsocket-websocket-client/src/WebsocketClientTransport.ts
@@ -3,7 +3,6 @@ import {
   Deserializer,
   DuplexConnection,
 } from "@rsocket/rsocket-core";
-import WebSocket, { ErrorEvent } from "ws";
 import { WebsocketDuplexConnection } from "./WebsocketDuplexConnection";
 
 export type ClientOptions = {

--- a/packages/rsocket-websocket-client/src/WebsocketDuplexConnection.ts
+++ b/packages/rsocket-websocket-client/src/WebsocketDuplexConnection.ts
@@ -6,7 +6,6 @@ import {
   serializeFrame,
   StreamIdGenerator,
 } from "@rsocket/rsocket-core";
-import WebSocket, { CloseEvent, ErrorEvent } from "ws";
 
 export class WebsocketDuplexConnection
   extends ClientServerInputMultiplexerDemultiplexer

--- a/packages/rsocket-websocket-client/src/__tests__/WebsocketDuplexConnection.spec.ts
+++ b/packages/rsocket-websocket-client/src/__tests__/WebsocketDuplexConnection.spec.ts
@@ -1,4 +1,3 @@
-import WebSocket from "ws";
 import { mock } from "jest-mock-extended";
 import {
   Deserializer,


### PR DESCRIPTION
Fixes #183.

Defaults to global `WebSocket` reference in `rsocket-websocket-client` for browser compatibility. non-browser environments can satisfy the dependency via the `wsCreator` configuration property.