### PR TITLE
feat: composite metadata routing example

### DIFF
--- a/packages/rsocket-composite-metadata/src/CompositeMetadata.ts
+++ b/packages/rsocket-composite-metadata/src/CompositeMetadata.ts
@@ -12,7 +12,6 @@ export class CompositeMetadata implements Iterable<Entry> {
     return decodeCompositeMetadata(this._buffer);
   }
 
-  // $FlowFixMe
   [Symbol.iterator](): Iterator<Entry> {
     return decodeCompositeMetadata(this._buffer);
   }

--- a/packages/rsocket-composite-metadata/src/RoutingMetadata.ts
+++ b/packages/rsocket-composite-metadata/src/RoutingMetadata.ts
@@ -9,7 +9,6 @@ export class RoutingMetadata implements Iterable<string> {
     return decodeRoutes(this._buffer);
   }
 
-  // $FlowFixMe
   [Symbol.iterator](): Iterator<string> {
     return decodeRoutes(this._buffer);
   }

--- a/packages/rsocket-examples/package.json
+++ b/packages/rsocket-examples/package.json
@@ -11,7 +11,8 @@
     "start-client-request-fnf-with-lease": "ts-node -r tsconfig-paths/register src/ClienRequestFnfnWithLeaseExampleTcp.ts",
     "start-client-server-request-stream-websocket": "ts-node -r tsconfig-paths/register src/ClientServerRequestStreamExampleWebSocket.ts",
     "start-client-server-request-response-tcp": "ts-node -r tsconfig-paths/register src/ClientServerRequestResponseExampleTcp.ts",
-    "start-client-server-request-response-websocket": "ts-node -r tsconfig-paths/register src/ClientServerRequestResponseExampleWebSocket.ts"
+    "start-client-server-request-response-websocket": "ts-node -r tsconfig-paths/register src/ClientServerRequestResponseExampleWebSocket.ts",
+    "start-client-server-composite-metadata-route": "ts-node -r tsconfig-paths/register src/ClientServerCompositeMetadataRouteExample.ts"
   },
   "dependencies": {
     "ws": "~8.0.0",

--- a/packages/rsocket-examples/src/ClientServerCompositeMetadataRouteExample.ts
+++ b/packages/rsocket-examples/src/ClientServerCompositeMetadataRouteExample.ts
@@ -1,0 +1,212 @@
+import {
+  ErrorCodes,
+  OnExtensionSubscriber,
+  OnNextSubscriber,
+  OnTerminalSubscriber,
+  Payload,
+  RSocket,
+  RSocketConnector,
+  RSocketError,
+  RSocketServer,
+} from "@rsocket/rsocket-core";
+import { TcpClientTransport } from "@rsocket/rsocket-tcp-client";
+import { TcpServerTransport } from "@rsocket/rsocket-tcp-server";
+import {
+  decodeCompositeMetadata,
+  decodeRoutes,
+  encodeCompositeMetadata,
+  encodeRoute,
+  WellKnownMimeType,
+} from "@rsocket/rsocket-composite-metadata";
+import { exit } from "process";
+import MESSAGE_RSOCKET_ROUTING = WellKnownMimeType.MESSAGE_RSOCKET_ROUTING;
+import Logger from "./shared/logger";
+
+let serverCloseable;
+
+function mapMetaData(payload: Payload) {
+  const mappedMetaData = new Map<string, any>();
+  if (payload.metadata) {
+    const decodedCompositeMetaData = decodeCompositeMetadata(payload.metadata);
+
+    for (let metaData of decodedCompositeMetaData) {
+      switch (metaData.mimeType) {
+        case MESSAGE_RSOCKET_ROUTING.toString(): {
+          const tags = [];
+          for (let decodedRoute of decodeRoutes(metaData.content)) {
+            tags.push(decodedRoute);
+          }
+          const joinedRoute = tags.join(".");
+          mappedMetaData.set(MESSAGE_RSOCKET_ROUTING.toString(), joinedRoute);
+        }
+      }
+    }
+  }
+  return mappedMetaData;
+}
+
+class EchoService {
+  handleEchoRequestResponse(
+    responderStream: OnTerminalSubscriber &
+      OnNextSubscriber &
+      OnExtensionSubscriber,
+    payload: Payload
+  ) {
+    const timeout = setTimeout(
+      () =>
+        responderStream.onNext(
+          {
+            data: Buffer.concat([Buffer.from("Echo: "), payload.data]),
+          },
+          true
+        ),
+      1000
+    );
+    return {
+      cancel: () => {
+        clearTimeout(timeout);
+        console.log("cancelled");
+      },
+      onExtension: () => {
+        console.log("Received Extension request");
+      },
+    };
+  }
+}
+
+function makeServer() {
+  return new RSocketServer({
+    transport: new TcpServerTransport({
+      listenOptions: {
+        port: 9090,
+        host: "127.0.0.1",
+      },
+    }),
+    acceptor: {
+      accept: async () => ({
+        requestResponse: (
+          payload: Payload,
+          responderStream: OnTerminalSubscriber &
+            OnNextSubscriber &
+            OnExtensionSubscriber
+        ) => {
+          const echoService = new EchoService();
+          const mappedMetaData = mapMetaData(payload);
+
+          const defaultSusbcriber = {
+            cancel() {
+              console.log("cancelled");
+            },
+            onExtension() {},
+          };
+
+          const route = mappedMetaData.get(MESSAGE_RSOCKET_ROUTING.toString());
+          if (!route) {
+            responderStream.onError(
+              new RSocketError(
+                ErrorCodes.REJECTED,
+                "Composite metadata did not include routing information."
+              )
+            );
+            return defaultSusbcriber;
+          }
+
+          switch (route) {
+            case "EchoService.echo": {
+              return echoService.handleEchoRequestResponse(
+                responderStream,
+                payload
+              );
+            }
+
+            default: {
+              responderStream.onError(
+                new RSocketError(
+                  ErrorCodes.REJECTED,
+                  "The encoded route was unknown by the server."
+                )
+              );
+              return defaultSusbcriber;
+            }
+          }
+        },
+      }),
+    },
+  });
+}
+
+function makeConnector() {
+  return new RSocketConnector({
+    transport: new TcpClientTransport({
+      connectionOptions: {
+        host: "127.0.0.1",
+        port: 9090,
+      },
+    }),
+  });
+}
+
+async function requestResponse(rsocket: RSocket, route?: string) {
+  let compositeMetaData = undefined;
+  if (route) {
+    const encodedRoute = encodeRoute(route);
+
+    const map = new Map<WellKnownMimeType, Buffer>();
+    map.set(MESSAGE_RSOCKET_ROUTING, encodedRoute);
+    compositeMetaData = encodeCompositeMetadata(map);
+  }
+
+  return new Promise((resolve, reject) => {
+    return rsocket.requestResponse(
+      {
+        data: Buffer.from("Hello World"),
+        metadata: compositeMetaData,
+      },
+      {
+        onError: (e) => {
+          reject(e);
+        },
+        onNext: (payload, isComplete) => {
+          Logger.info(
+            `payload[data: ${payload.data}; metadata: ${payload.metadata}]|${isComplete}`
+          );
+          resolve(payload);
+        },
+        onComplete: () => {},
+        onExtension: () => {},
+      }
+    );
+  });
+}
+
+async function main() {
+  const server = makeServer();
+  const connector = makeConnector();
+
+  serverCloseable = await server.bind();
+  const rsocket = await connector.connect();
+
+  // this request will pass
+  await requestResponse(rsocket, "EchoService.echo");
+
+  // this request will reject (unknown route)
+  try {
+    await requestResponse(rsocket, "UnknownService.unknown");
+  } catch (e) {
+    Logger.error(e);
+  }
+
+  // this request will reject (no routing data)
+  try {
+    await requestResponse(rsocket);
+  } catch (e) {
+    Logger.error(e);
+  }
+}
+
+main()
+  .then(() => exit())
+  .catch((error: Error) => {
+    console.error(error);
+    exit(1);
+  });

--- a/packages/rsocket-examples/src/shared/logger.ts
+++ b/packages/rsocket-examples/src/shared/logger.ts
@@ -6,4 +6,12 @@ export default class Logger {
       .replace(/\..+/, ""); // delete the dot and everything after;
     return console.log(`[${date}] ${message}`, ...rest);
   }
+
+  static error(message, ...rest) {
+    const date = new Date()
+      .toISOString()
+      .replace(/T/, " ") // replace T with a space
+      .replace(/\..+/, ""); // delete the dot and everything after;
+    return console.error(`[${date}] ${message}`, ...rest);
+  }
 }


### PR DESCRIPTION
Adds an example of composite metadata with routing, in order to exercise and proof composite metadata additions.