### PR TITLE
Add keepLive, lifetime, metadataMimeType, dataMimeType attributes for setupPayload

### DIFF
--- a/packages/rsocket-core/src/RSocketServer.js
+++ b/packages/rsocket-core/src/RSocketServer.js
@@ -22,6 +22,7 @@ import type {
   Frame,
   FrameWithData,
   Payload,
+  SetupPayload,
   ReactiveSocket,
   PartialResponder,
 } from 'rsocket-types';
@@ -178,7 +179,7 @@ export default class RSocketServer<D, M> {
                 responderLeaseHandler,
               );
               try {
-                const setupPayload = deserializePayload(serializers, frame);
+                const setupPayload: SetupPayload = deserializePayload(serializers, frame);
                 setupPayload.keepAlive = frame.keepAlive;
                 setupPayload.lifetime = frame.lifetime;
                 setupPayload.metadataMimeType = frame.metadataMimeType;

--- a/packages/rsocket-core/src/RSocketServer.js
+++ b/packages/rsocket-core/src/RSocketServer.js
@@ -178,9 +178,14 @@ export default class RSocketServer<D, M> {
                 responderLeaseHandler,
               );
               try {
+                const setupPayload = deserializePayload(serializers, frame);
+                setupPayload.keepAlive = frame.keepAlive;
+                setupPayload.lifetime = frame.lifetime;
+                setupPayload.metadataMimeType = frame.metadataMimeType;
+                setupPayload.dataMimeType = frame.dataMimeType;
                 const requestHandler = this._config.getRequestHandler(
                   serverMachine,
-                  deserializePayload(serializers, frame),
+                  setupPayload,
                 );
                 serverMachine.setRequestHandler(requestHandler);
                 this._connections.add(serverMachine);

--- a/packages/rsocket-types/src/ReactiveSocketTypes.js
+++ b/packages/rsocket-types/src/ReactiveSocketTypes.js
@@ -174,6 +174,18 @@ export type Payload<D, M> = {|
   metadata: ?M,
 |};
 
+/**
+ * A single unit of data for connection from the peers of a `ReactiveSocket`.
+ */
+ export type SetupPayload<D, M> = {|
+  data: ?D,
+  metadata: ?M,
+  keepAlive: number,
+  lifetime: number,
+  metadataMimeType: ?string,
+  dataMimeType: ?string
+|};
+
 export type Frame =
   | CancelFrame
   | ErrorFrame


### PR DESCRIPTION
Now setupPayload contains data and metadata only, and it should contains keepLive, lifetime, metadataMimeType, dataMimeType attributes.  metadataMimeType and dataMimeType is very useful for data encoding/decoding on connection level.
