### PR TITLE
chore: remove hasBufferModule code

### DIFF
--- a/packages/rsocket-core/src/LiteBuffer.js
+++ b/packages/rsocket-core/src/LiteBuffer.js
@@ -6,7 +6,7 @@ import ExistingBufferModule from 'buffer';
 
 const hasGlobalBuffer =
   typeof global !== 'undefined' && global.hasOwnProperty('Buffer');
-const hasBufferModule = ExistingBufferModule.hasOwnProperty('Buffer');
+
 
 function notImplemented(msg?: string): void {
   const message = msg ? `Not implemented: ${msg}` : 'Not implemented';
@@ -605,10 +605,7 @@ export class Buffer extends Uint8Array {
    * Returns true if obj is a Buffer, false otherwise.
    */
   static isBuffer(obj: any): boolean {
-    return (
-      isInstance(obj, Buffer) ||
-      (!hasGlobalBuffer && hasBufferModule && isInstance(obj, Uint8Array))
-    );
+    return isInstance(obj, Buffer);
   }
 
   static isEncoding(encoding: any): boolean {
@@ -996,17 +993,6 @@ export class Buffer extends Uint8Array {
 }
 
 if (!hasGlobalBuffer) {
-  if (hasBufferModule) {
-    // ExistingBuffer is likely to be a polyfill, hence we can override it
-    // eslint-disable-next-line no-undef
-    // $FlowFixMe
-    Object.defineProperty(ExistingBufferModule, 'Buffer', {
-      configurable: true,
-      enumerable: false,
-      value: Buffer,
-      writable: true,
-    });
-  }
   // eslint-disable-next-line no-undef
   Object.defineProperty(window, 'Buffer', {
     configurable: true,


### PR DESCRIPTION
remove hasBufferModule code that makes RSocket-js can't work in browser

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
