### PR TITLE
fix: add Metadata flag when sending stream payload which has metadata

### DIFF
--- a/packages/rsocket-core/src/RSocketMachine.js
+++ b/packages/rsocket-core/src/RSocketMachine.js
@@ -888,7 +888,8 @@ class RSocketMachineImpl<D, M> implements RSocketMachine<D, M> {
       flags |= FLAGS.COMPLETE;
       this._subscriptions.delete(streamId);
     }
-    if (payload.metadata !== undefined) {
+    if (payload.metadata !== undefined &&
+        payload.metadata !== null) {
       // eslint-disable-next-line no-bitwise
       flags |= FLAGS.METADATA;
     }

--- a/packages/rsocket-core/src/RSocketMachine.js
+++ b/packages/rsocket-core/src/RSocketMachine.js
@@ -888,7 +888,7 @@ class RSocketMachineImpl<D, M> implements RSocketMachine<D, M> {
       flags |= FLAGS.COMPLETE;
       this._subscriptions.delete(streamId);
     }
-    if (metadata !== undefined) {
+    if (payload.metadata !== undefined) {
       // eslint-disable-next-line no-bitwise
       flags |= FLAGS.METADATA;
     }

--- a/packages/rsocket-core/src/RSocketMachine.js
+++ b/packages/rsocket-core/src/RSocketMachine.js
@@ -888,6 +888,10 @@ class RSocketMachineImpl<D, M> implements RSocketMachine<D, M> {
       flags |= FLAGS.COMPLETE;
       this._subscriptions.delete(streamId);
     }
+    if (metadata !== undefined) {
+      // eslint-disable-next-line no-bitwise
+      flags |= FLAGS.METADATA;
+    }
     const data = this._serializers.data.serialize(payload.data);
     const metadata = this._serializers.metadata.serialize(payload.metadata);
     this._connection.sendOne({


### PR DESCRIPTION
### Motivation:

Addresses #198 

### Modifications:

Add Metadata flag as needed when sending stream payload.

### Result:

Metadata should be included in encoded payloads.
