### PR TITLE
docs: updates readme to callout master branch as source for 0.x.x versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
+## Under Development
 
-# Under Development
-
-**This branch is a work in progress rewrite of rsocket-js from [Flow](https://flow.org/) to [TypeScript](https://www.typescriptlang.org/).**
+**This branch is a work in progress rewrite of rsocket-js from [Flow](https://flow.org/) to [TypeScript](https://www.typescriptlang.org/). Please see [#158](https://github.com/rsocket/rsocket-js/issues/158).**
 
 **You SHOULD NOT leverage any artifacts published from this branch as all are considered unstable.**
 
+**Please see the [master](https://github.com/rsocket/rsocket-js/tree/master) branch for source used to publish the latest `0.x.x` versions on NPM.**
+
 # [rsocket-js](https://github.com/rsocket/rsocket-js)
 
-[![Build Status](https://github.com/rsocket/rsocket-js/actions/workflows/test.yml/badge.svg)](https://github.com/rsocket/rsocket-js/actions/workflows/test.yml)
+[![Build](https://github.com/rsocket/rsocket-js/actions/workflows/build.yml/badge.svg?branch=1.0.x)](https://github.com/rsocket/rsocket-js/actions/workflows/build.yml)
 
 A JavaScript implementation of the [RSocket](https://github.com/rsocket/rsocket)
 protocol intended for use in browsers and/or Node.js. From [rsocket.io](http://rsocket.io/):
@@ -31,7 +32,7 @@ TODO: add install instructions
 
 ## Contributing
 
-See the `CONTRIBUTING.md` file for how to help out.
+TODO: add `CONTRIBUTING.md`
 
 ## Documentation
 


### PR DESCRIPTION
Updates README to point visitors to the master branch for source related to the `0.x.x` releases on NPM.