### PR TITLE
chore: split ci workflow compile and test jobs to run seperate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,37 @@ jobs:
       - name: Lint
         run: yarn lint
 
-  compile_and_test:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.yarn
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Test
+        run: yarn test
+
+  compile:
     runs-on: ubuntu-latest
 
     steps:
@@ -65,6 +95,3 @@ jobs:
 
       - name: Compile
         run: yarn build
-
-      - name: Test
-        run: yarn test


### PR DESCRIPTION
Splits compile and test workflow jobs to run separately so that we can more easily see which stage of the build may be experiencing issues.

Previously `test` required `compile` to be run first, but with recent changes, tests now do compilation just in time.