### PR TITLE
fix/custom metadata header alloc

### DIFF
--- a/packages/rsocket-composite-metadata/__tests__/encodeAndAddCustomMetadata.spec.ts
+++ b/packages/rsocket-composite-metadata/__tests__/encodeAndAddCustomMetadata.spec.ts
@@ -1,0 +1,40 @@
+import { encodeAndAddCustomMetadata } from "rsocket-composite-metadata";
+import { hex } from "./test-utils/hex";
+
+describe("encodeAndAddCustomMetadata", () => {
+  it("throws if custom mimtype length is less than 1", () => {
+    expect(() =>
+      encodeAndAddCustomMetadata(Buffer.from([]), "", Buffer.from("1234"))
+    ).toThrow(
+      "Custom mime type must have a strictly positive length that fits on 7 unsigned bits, ie 1-128"
+    );
+  });
+
+  it("throws if custom mimtype length is greater than 127", () => {
+    let mime = "";
+    while (mime.length < 130) {
+      mime += "a";
+    }
+    expect(() =>
+      encodeAndAddCustomMetadata(Buffer.from([]), mime, Buffer.from("1234"))
+    ).toThrow(
+      "Custom mime type must have a strictly positive length that fits on 7 unsigned bits, ie 1-128"
+    );
+  });
+
+  it("encodes the header and payload as per spec", () => {
+    const { c, u, s, t, o, m } = hex;
+    const metadata = encodeAndAddCustomMetadata(
+      Buffer.from([]),
+      "custom",
+      Buffer.from("1234")
+    );
+    const expectedHeaderLength8 = "05";
+    const expectedPayloadLength24 = "000004";
+    const expectedHeader = `${expectedHeaderLength8}${c}${u}${s}${t}${o}${m}${expectedPayloadLength24}`;
+    const expectedPayload = `${hex["1"]}${hex["2"]}${hex["3"]}${hex["4"]}`;
+    expect(metadata.toString("hex")).toBe(
+      `${expectedHeader}${expectedPayload}`
+    );
+  });
+});

--- a/packages/rsocket-composite-metadata/__tests__/encodeCustomMetadataHeader.ts
+++ b/packages/rsocket-composite-metadata/__tests__/encodeCustomMetadataHeader.ts
@@ -1,0 +1,33 @@
+import { encodeCustomMetadataHeader } from "rsocket-composite-metadata";
+import { hex } from "./test-utils/hex";
+
+describe("encodeCustomMetadataHeader", () => {
+  it("throws if length is less than 1", () => {
+    expect(() => encodeCustomMetadataHeader("", 0)).toThrow(
+      "Custom mime type must have a strictly positive length that fits on 7 unsigned bits, ie 1-128"
+    );
+  });
+
+  it("throws if length is greater than 127", () => {
+    let mime = "";
+    while (mime.length < 130) {
+      mime += "a";
+    }
+    expect(() => encodeCustomMetadataHeader(mime, mime.length)).toThrow(
+      "Custom mime type must have a strictly positive length that fits on 7 unsigned bits, ie 1-128"
+    );
+  });
+
+  it("encodes the header as per spec", () => {
+    const { t, e, s } = hex;
+    const mime = "test";
+    // length minus 1 (uint8)
+    const expectedLength8 = "03";
+    // full length (uint24)
+    const expectedLength24 = "000004";
+    const header = encodeCustomMetadataHeader(mime, mime.length);
+    expect(header.toString("hex")).toBe(
+      `${expectedLength8}${t}${e}${s}${t}${expectedLength24}`
+    );
+  });
+});

--- a/packages/rsocket-composite-metadata/__tests__/test-utils/hex.ts
+++ b/packages/rsocket-composite-metadata/__tests__/test-utils/hex.ts
@@ -1,0 +1,26 @@
+function numHex(s) {
+  let a = s.toString(16);
+  if (a.length % 2 > 0) {
+    a = "0" + a;
+  }
+  return a;
+}
+
+function strHex(s) {
+  let a = "";
+  for (let i = 0; i < s.length; i++) {
+    a = a + numHex(s.charCodeAt(i));
+  }
+
+  return a;
+}
+
+const numeric = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+// const numericChars = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+const alphabetNumeric = "abcdefghijklmnopqrstuvqxyz0123456789";
+
+export const hex: any = {};
+
+alphabetNumeric.split("").forEach((c) => {
+  hex[c] = strHex(c);
+});

--- a/packages/rsocket-composite-metadata/__tests__/test-utils/hex.ts
+++ b/packages/rsocket-composite-metadata/__tests__/test-utils/hex.ts
@@ -15,8 +15,6 @@ function strHex(s) {
   return a;
 }
 
-const numeric = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-// const numericChars = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
 const alphabetNumeric = "abcdefghijklmnopqrstuvqxyz0123456789";
 
 export const hex: any = {};

--- a/packages/rsocket-composite-metadata/jest.config.ts
+++ b/packages/rsocket-composite-metadata/jest.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from "@jest/types";
+import { pathsToModuleNameMapper } from "ts-jest/utils";
+import { compilerOptions } from "../../tsconfig.json";
+
+const config: Config.InitialOptions = {
+  preset: "ts-jest",
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    // This has to match the baseUrl defined in tsconfig.json.
+    prefix: "<rootDir>/../../",
+  }),
+  modulePathIgnorePatterns: ["<rootDir>/__tests__/test-utils"],
+  collectCoverage: true,
+  collectCoverageFrom: ["<rootDir>/src/**/*.ts", "!**/node_modules/**"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+};
+
+export default config;

--- a/packages/rsocket-composite-metadata/jest.setup.ts
+++ b/packages/rsocket-composite-metadata/jest.setup.ts
@@ -1,0 +1,1 @@
+expect.extend({});

--- a/packages/rsocket-composite-metadata/package.json
+++ b/packages/rsocket-composite-metadata/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf -rf ./dist",
     "compile": "tsc -p tsconfig.build.json",
     "prepublishOnly": "yarn run build",
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "yarn jest"
   },
   "dependencies": {
     "rsocket-core": "^1.0.0-alpha.1"

--- a/packages/rsocket-composite-metadata/src/CompositeMetadata.ts
+++ b/packages/rsocket-composite-metadata/src/CompositeMetadata.ts
@@ -170,14 +170,14 @@ export function encodeCustomMetadataHeader(
   customMime: string,
   metadataLength: number
 ): Buffer {
+  // allocate one byte + the length of the mimetype
   const metadataHeader: Buffer = Buffer.allocUnsafe(4 + customMime.length);
-  // reserve 1 byte for the customMime length
-  // /!\ careful not to read that first byte, which is random at this point
-  // int writerIndexInitial = metadataHeader.writerIndex();
-  // metadataHeader.writerIndex(writerIndexInitial + 1);
+
+  // fill the buffer to clear previous memory
+  metadataHeader.fill(0);
 
   // write the custom mime in UTF8 but validate it is all ASCII-compatible
-  // (which produces the right result since ASCII chars are still encoded on 1 byte in UTF8)
+  // (which produces the correct result since ASCII chars are still encoded on 1 byte in UTF8)
   const customMimeLength: number = metadataHeader.write(customMime, 1);
   if (!isAscii(metadataHeader, 1)) {
     throw new Error("Custom mime type must be US_ASCII characters only");


### PR DESCRIPTION
Addresses #230

### Motivation:

Usage of `Buffer.allocUnsafe` had the potential for leaking previously allocated memory in custom metadata headers.

### Modifications:

Fill buffer allocated for custom metadata header prior to writing.

### Result:

Buffer allocated for custom metadata header is prevented from containing values from previously allocated memory.
