### PR TITLE
Optional metadata for rxjs requesters

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -11,7 +11,7 @@
     },
     "version": {
       "push": false,
-      "allowBranch": ["main", "1.0.x-alpha", "feature/rxjs-adapter-optional-metadata"]
+      "allowBranch": ["main", "1.0.x-alpha"]
     }
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -11,7 +11,7 @@
     },
     "version": {
       "push": false,
-      "allowBranch": ["main", "1.0.x-alpha"]
+      "allowBranch": ["main", "1.0.x-alpha", "feature/rxjs-adapter-optional-metadata"]
     }
   }
 }

--- a/packages/rsocket-adapter-rxjs/package.json
+++ b/packages/rsocket-adapter-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsocket-adapter-rxjs",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha-rxjs-adapter-optional-metadata.0",
   "license": "Apache-2.0",
   "main": "dist/index",
   "types": "dist/index",
@@ -19,8 +19,8 @@
     "test": "echo \"Error: no test specified\" && exit 0"
   },
   "dependencies": {
-    "rsocket-core": "^1.0.0-alpha.1",
-    "rsocket-messaging": "^1.0.0-alpha.2",
+    "rsocket-core": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0",
+    "rsocket-messaging": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0",
     "rxjs": "^7.4.0"
   },
   "devDependencies": {

--- a/packages/rsocket-composite-metadata/package.json
+++ b/packages/rsocket-composite-metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsocket-composite-metadata",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha-rxjs-adapter-optional-metadata.0",
   "license": "Apache-2.0",
   "main": "dist/index",
   "types": "dist/index",
@@ -19,7 +19,7 @@
     "test": "yarn jest"
   },
   "dependencies": {
-    "rsocket-core": "^1.0.0-alpha.1"
+    "rsocket-core": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0"
   },
   "devDependencies": {
     "rimraf": "~3.0.2",

--- a/packages/rsocket-core/package.json
+++ b/packages/rsocket-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsocket-core",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha-rxjs-adapter-optional-metadata.0",
   "license": "Apache-2.0",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/rsocket-examples/package.json
+++ b/packages/rsocket-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsocket-examples",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha-rxjs-adapter-optional-metadata.0",
   "license": "Apache-2.0",
   "private": true,
   "files": [
@@ -19,13 +19,13 @@
     "start-client-server-rx-composite-metadata-route": "ts-node -r tsconfig-paths/register src/rxjs/ClientServerCompositeMetadataRouteExample.ts"
   },
   "dependencies": {
-    "rsocket-adapter-rxjs": "^1.0.0-alpha.2",
-    "rsocket-composite-metadata": "^1.0.0-alpha.2",
-    "rsocket-core": "^1.0.0-alpha.1",
-    "rsocket-tcp-client": "^1.0.0-alpha.1",
-    "rsocket-tcp-server": "^1.0.0-alpha.1",
-    "rsocket-websocket-client": "^1.0.0-alpha.1",
-    "rsocket-websocket-server": "^1.0.0-alpha.1",
+    "rsocket-adapter-rxjs": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0",
+    "rsocket-composite-metadata": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0",
+    "rsocket-core": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0",
+    "rsocket-tcp-client": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0",
+    "rsocket-tcp-server": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0",
+    "rsocket-websocket-client": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0",
+    "rsocket-websocket-server": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0",
     "ws": "~8.2.3"
   },
   "devDependencies": {

--- a/packages/rsocket-messaging/package.json
+++ b/packages/rsocket-messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsocket-messaging",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha-rxjs-adapter-optional-metadata.0",
   "license": "Apache-2.0",
   "main": "dist/index",
   "types": "dist/index",
@@ -19,8 +19,8 @@
     "test": "echo \"Error: no test specified\" && exit 0"
   },
   "dependencies": {
-    "rsocket-composite-metadata": "^1.0.0-alpha.2",
-    "rsocket-core": "^1.0.0-alpha.1"
+    "rsocket-composite-metadata": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0",
+    "rsocket-core": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0"
   },
   "devDependencies": {
     "rimraf": "~3.0.2",

--- a/packages/rsocket-tcp-client/package.json
+++ b/packages/rsocket-tcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsocket-tcp-client",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha-rxjs-adapter-optional-metadata.0",
   "license": "Apache-2.0",
   "main": "dist/index",
   "types": "dist/index",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "rsocket-core": "^1.0.0-alpha.1"
+    "rsocket-core": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0"
   },
   "devDependencies": {
     "rimraf": "~3.0.2",

--- a/packages/rsocket-tcp-server/package.json
+++ b/packages/rsocket-tcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsocket-tcp-server",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha-rxjs-adapter-optional-metadata.0",
   "license": "Apache-2.0",
   "main": "dist/index",
   "types": "dist/index",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "rsocket-core": "^1.0.0-alpha.1"
+    "rsocket-core": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0"
   },
   "devDependencies": {
     "rimraf": "~3.0.2",

--- a/packages/rsocket-websocket-client/package.json
+++ b/packages/rsocket-websocket-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsocket-websocket-client",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha-rxjs-adapter-optional-metadata.0",
   "license": "Apache-2.0",
   "main": "dist/index",
   "types": "dist/index",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "rsocket-core": "^1.0.0-alpha.1"
+    "rsocket-core": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0"
   },
   "devDependencies": {
     "rimraf": "~3.0.2",

--- a/packages/rsocket-websocket-server/package.json
+++ b/packages/rsocket-websocket-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsocket-websocket-server",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha-rxjs-adapter-optional-metadata.0",
   "license": "Apache-2.0",
   "main": "dist/index",
   "types": "dist/index",
@@ -20,7 +20,7 @@
     "test": "echo \"Error: no test specified\" && exit 0"
   },
   "dependencies": {
-    "rsocket-core": "^1.0.0-alpha.1",
+    "rsocket-core": "^1.0.0-alpha-rxjs-adapter-optional-metadata.0",
     "ws": "~8.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
### Motivation:

Addressed feedback: https://github.com/rsocket/rsocket-js/issues/158#issuecomment-1208040376

### Modifications:

Allow optional `metadata` argument in rxjs requesters

### Result:

Allows for:

```ts
const rsocket = await connector.connect();

let requestResponse = RxRequestersFactory.requestResponse(
  "Hello World",
  stringCodec,
  stringCodec
);

let stringObservable = requestResponse(rsocket);
```

Where previously passing `new Map()` would have been required.

```ts
let stringObservable = requestResponse(rsocket, new Map());
```