### PR TITLE
fixes request channel to drop second element

### DIFF
--- a/packages/rsocket-adapter-rxjs/src/Requesters.ts
+++ b/packages/rsocket-adapter-rxjs/src/Requesters.ts
@@ -136,6 +136,7 @@ export function requestChannel<TData, RData>(
   rsocket: RSocket,
   metadata?: Map<string | number | WellKnownMimeType, Buffer>
 ) => Observable<RData> {
+  let once = false;
   const [firstValueObservable, restValuesObservable] = partition(
     datas.pipe(
       share({
@@ -143,7 +144,14 @@ export function requestChannel<TData, RData>(
         resetOnRefCountZero: true,
       })
     ),
-    (_value, index) => index === 0
+    (_value) => {
+      const previous = once;
+      if (!previous) {
+        once = true;
+      }
+
+      return !previous;
+    }
   );
 
   return (


### PR DESCRIPTION
closes #234 

unexpectedly, the index is a local variable per subscription, thus the second subscription starts indexing from 0 once again even though the element is a second one (index should be 1 in that case). Therefore, to overcome this problem the PR introduces a local variable to track the first element.

Signed-off-by: Oleh Dokuka <odokuka@vmware.com>
Signed-off-by: Oleh Dokuka <oleh.dokuka@icloud.com>
