### PR TITLE
fix: build script supports Windows

### DIFF
--- a/packages/rsocket-core/package.json
+++ b/packages/rsocket-core/package.json
@@ -12,5 +12,5 @@
     "rsocket-flowable": "^0.0.28",
     "rsocket-types": "^0.0.28"
   },
-  "gitHead": "1e15f3c9752f17a06537ee8741900ba12a151a42"
+  "gitHead": "844d70d3a7fd3cbb193a8b853297b6c5cc73e722"
 }

--- a/packages/rsocket-flowable/package.json
+++ b/packages/rsocket-flowable/package.json
@@ -8,5 +8,5 @@
   },
   "license": "BSD-3-Clause",
   "main": "build/index.js",
-  "gitHead": "1e15f3c9752f17a06537ee8741900ba12a151a42"
+  "gitHead": "844d70d3a7fd3cbb193a8b853297b6c5cc73e722"
 }

--- a/packages/rsocket-tck/package.json
+++ b/packages/rsocket-tck/package.json
@@ -13,5 +13,5 @@
     "rsocket-flowable": "^0.0.28",
     "rsocket-tcp-client": "^0.0.28"
   },
-  "gitHead": "1e15f3c9752f17a06537ee8741900ba12a151a42"
+  "gitHead": "844d70d3a7fd3cbb193a8b853297b6c5cc73e722"
 }

--- a/packages/rsocket-tcp-client/package.json
+++ b/packages/rsocket-tcp-client/package.json
@@ -13,5 +13,5 @@
     "rsocket-flowable": "^0.0.28",
     "rsocket-types": "^0.0.28"
   },
-  "gitHead": "1e15f3c9752f17a06537ee8741900ba12a151a42"
+  "gitHead": "844d70d3a7fd3cbb193a8b853297b6c5cc73e722"
 }

--- a/packages/rsocket-tcp-server/package.json
+++ b/packages/rsocket-tcp-server/package.json
@@ -14,5 +14,5 @@
     "rsocket-tcp-client": "^0.0.28",
     "rsocket-types": "^0.0.28"
   },
-  "gitHead": "1e15f3c9752f17a06537ee8741900ba12a151a42"
+  "gitHead": "844d70d3a7fd3cbb193a8b853297b6c5cc73e722"
 }

--- a/packages/rsocket-types/package.json
+++ b/packages/rsocket-types/package.json
@@ -11,5 +11,5 @@
   "dependencies": {
     "rsocket-flowable": "^0.0.28"
   },
-  "gitHead": "1e15f3c9752f17a06537ee8741900ba12a151a42"
+  "gitHead": "844d70d3a7fd3cbb193a8b853297b6c5cc73e722"
 }

--- a/packages/rsocket-websocket-client/package.json
+++ b/packages/rsocket-websocket-client/package.json
@@ -13,5 +13,5 @@
     "rsocket-flowable": "^0.0.28",
     "rsocket-types": "^0.0.28"
   },
-  "gitHead": "1e15f3c9752f17a06537ee8741900ba12a151a42"
+  "gitHead": "844d70d3a7fd3cbb193a8b853297b6c5cc73e722"
 }

--- a/packages/rsocket-websocket-server/package.json
+++ b/packages/rsocket-websocket-server/package.json
@@ -14,5 +14,5 @@
     "rsocket-types": "^0.0.28",
     "ws": "^7.3.1"
   },
-  "gitHead": "1e15f3c9752f17a06537ee8741900ba12a151a42"
+  "gitHead": "844d70d3a7fd3cbb193a8b853297b6c5cc73e722"
 }


### PR DESCRIPTION
### Motivation:

Running the the build script on windows produces incorrect output.

### Modifications:

- Build script normalizes file paths to posix to support Windows and Linux.

### Result:

Source files are now transpiled when build script is run on Windows.

This should allow me to re-publish a new version from `master` to address #275
