### PR TITLE
Fix: WebSocket Duplex Connection Unhandled Exceptions 

### DIFF
--- a/packages/rsocket-websocket-server/src/WebsocketServerTransport.ts
+++ b/packages/rsocket-websocket-server/src/WebsocketServerTransport.ts
@@ -23,10 +23,10 @@ import {
   FrameHandler,
   Multiplexer,
   Outbound,
-  ServerTransport,
-} from "rsocket-core";
-import WebSocket, { Server } from "ws";
-import { WebsocketDuplexConnection } from "./WebsocketDuplexConnection";
+  ServerTransport
+} from 'rsocket-core';
+import WebSocket, { Server } from 'ws';
+import { WebsocketDuplexConnection } from './WebsocketDuplexConnection';
 
 export type SocketFactory = (options: SocketOptions) => Server;
 
@@ -43,7 +43,7 @@ export type ServerOptions = SocketOptions & {
 const defaultFactory: SocketFactory = (options: SocketOptions) => {
   return new Server({
     host: options.host,
-    port: options.port,
+    port: options.port
   });
 };
 
@@ -59,10 +59,7 @@ export class WebsocketServerTransport implements ServerTransport {
   }
 
   async bind(
-    connectionAcceptor: (
-      frame: Frame,
-      connection: DuplexConnection
-    ) => Promise<void>,
+    connectionAcceptor: (frame: Frame, connection: DuplexConnection) => Promise<void>,
     multiplexerDemultiplexerFactory: (
       frame: Frame,
       outbound: Outbound & Closeable
@@ -72,22 +69,18 @@ export class WebsocketServerTransport implements ServerTransport {
     const serverCloseable = new ServerCloseable(websocketServer);
 
     const connectionListener = (websocket: WebSocket) => {
-      websocket.binaryType = "nodebuffer";
+      websocket.binaryType = 'nodebuffer';
       const duplex = WebSocket.createWebSocketStream(websocket);
-      WebsocketDuplexConnection.create(
-        duplex,
-        connectionAcceptor,
-        multiplexerDemultiplexerFactory
-      );
+      WebsocketDuplexConnection.create(duplex, connectionAcceptor, multiplexerDemultiplexerFactory, websocket);
     };
 
     const closeListener = (error?: Error) => {
       serverCloseable.close(error);
     };
 
-    websocketServer.addListener("connection", connectionListener);
-    websocketServer.addListener("close", closeListener);
-    websocketServer.addListener("error", closeListener);
+    websocketServer.addListener('connection', connectionListener);
+    websocketServer.addListener('close', closeListener);
+    websocketServer.addListener('error', closeListener);
 
     return serverCloseable;
   }
@@ -96,16 +89,16 @@ export class WebsocketServerTransport implements ServerTransport {
     return new Promise((resolve, reject) => {
       const websocketServer = this.factory({
         host: this.host,
-        port: this.port,
+        port: this.port
       });
 
       const earlyCloseListener = (error?: Error) => {
         reject(error);
       };
 
-      websocketServer.addListener("close", earlyCloseListener);
-      websocketServer.addListener("error", earlyCloseListener);
-      websocketServer.addListener("listening", () => resolve(websocketServer));
+      websocketServer.addListener('close', earlyCloseListener);
+      websocketServer.addListener('error', earlyCloseListener);
+      websocketServer.addListener('listening', () => resolve(websocketServer));
     });
   }
 }

--- a/packages/rsocket-websocket-server/src/index.ts
+++ b/packages/rsocket-websocket-server/src/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-"use strict";
+'use strict';
 
-export * from "./WebsocketServerTransport";
+export * from './WebsocketServerTransport';
+export * from './WebsocketDuplexConnection';


### PR DESCRIPTION
This fixes some potential unhandled exceptions in `rsocket-websocket-server` relating to the underlying WebSocket `readyState` and deserialisation of invalid frames.

### Motivation:

I've noticed intermittent unhandled exceptions for the errors below:

WebSocket is in CLOSING state:
<img width="1126" alt="image" src="https://github.com/rsocket/rsocket-js/assets/51082125/ef681841-304d-4a89-8d59-4de6334eee91">

Unable to read `type` of undefined frame:
![image](https://github.com/rsocket/rsocket-js/assets/51082125/2f805e8e-da40-46ba-a299-ab68b3297b19)

### Modifications:

#### WebSocket readyState

The WebSocket from the `ws` library is now used to check the `readyState` before calling `write` on the Duplex stream. 

#### Undefined frame:

I believe this error was caused by the `deserializeFrame` method returning undefined. This could be verified by a client connecting to the server WebSocket port and sending a random Buffer payload. 

The connection will now close if no valid frame could be deserialised. 

### Result:

The external API and behaviour should be the same as before. There should now be less potential for unhandled exceptions.

### Side Note:

I've noticed some formatting changes were included here. Is there perhaps a Prettier config I could use? Running `yarn lint` on my machine also shows errors for other package's files. Perhaps this is somehow linking to external settings I might have. Please advise. 
