### PR TITLE
chore: add example of passing bearer auth token with setup frame

### DIFF
--- a/packages/rsocket-examples/package.json
+++ b/packages/rsocket-examples/package.json
@@ -23,7 +23,9 @@
     "start-client-apollo-graphql": "ts-node -r tsconfig-paths/register src/graphql/apollo/client/example.ts",
     "start-client-server-apollo-graphql": "ts-node -r tsconfig-paths/register src/graphql/apollo/client-server/example.ts",
     "start-client-server-composite-metadata-auth-example-client": "ts-node -r tsconfig-paths/register src/composite-metadata/bearer-token-auth/client.ts",
-    "start-client-server-composite-metadata-auth-example-server": "ts-node -r tsconfig-paths/register src/composite-metadata/bearer-token-auth/server.ts"
+    "start-client-server-composite-metadata-auth-example-server": "ts-node -r tsconfig-paths/register src/composite-metadata/bearer-token-auth/server.ts",
+    "start-client-server-composite-metadata-auth-setup-frame-example-client": "ts-node -r tsconfig-paths/register src/composite-metadata/bearer-token-auth-setup-frame/client.ts",
+    "start-client-server-composite-metadata-auth-setup-frame-example-server": "ts-node -r tsconfig-paths/register src/composite-metadata/bearer-token-auth-setup-frame/server.ts"
   },
   "dependencies": {
     "@apollo/client": "^3.5.10",

--- a/packages/rsocket-examples/src/composite-metadata/bearer-token-auth-setup-frame/client.ts
+++ b/packages/rsocket-examples/src/composite-metadata/bearer-token-auth-setup-frame/client.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Payload, RSocket, RSocketConnector } from "rsocket-core";
+import { TcpClientTransport } from "rsocket-tcp-client";
+import {
+  encodeBearerAuthMetadata,
+  encodeCompositeMetadata,
+  encodeRoute,
+  WellKnownMimeType,
+} from "rsocket-composite-metadata";
+import { exit } from "process";
+import Logger from "../../shared/logger";
+import MESSAGE_RSOCKET_ROUTING = WellKnownMimeType.MESSAGE_RSOCKET_ROUTING;
+import MESSAGE_RSOCKET_AUTHENTICATION = WellKnownMimeType.MESSAGE_RSOCKET_AUTHENTICATION;
+
+function makeMetadata(bearerToken?: string, route?: string) {
+  const map = new Map<WellKnownMimeType, Buffer>();
+
+  if (bearerToken) {
+    map.set(
+      MESSAGE_RSOCKET_AUTHENTICATION,
+      encodeBearerAuthMetadata(Buffer.from(bearerToken))
+    );
+  }
+
+  if (route) {
+    const encodedRoute = encodeRoute(route);
+    map.set(MESSAGE_RSOCKET_ROUTING, encodedRoute);
+  }
+
+  return encodeCompositeMetadata(map);
+}
+
+function makeConnector(token: string) {
+  // NOTE: THIS EXAMPLE DOES NOT COVER TLS.
+  //       ALWAYS USE A SECURE CONNECTION SUCH AS TLS WHEN TRANSMITTING SENSITIVE INFORMATION SUCH AS AUTH TOKENS.
+  return new RSocketConnector({
+    transport: new TcpClientTransport({
+      connectionOptions: {
+        host: "127.0.0.1",
+        port: 9090,
+      },
+    }),
+    setup: {
+      payload: {
+        data: Buffer.from([]),
+        metadata: makeMetadata(token),
+      },
+    },
+  });
+}
+
+async function requestResponse(
+  rsocket: RSocket,
+  compositeMetaData: Buffer,
+  message: string = ""
+): Promise<Payload> {
+  return new Promise((resolve, reject) => {
+    return rsocket.requestResponse(
+      {
+        data: Buffer.from(message),
+        metadata: compositeMetaData,
+      },
+      {
+        onError: (e) => {
+          reject(e);
+        },
+        onNext: (payload, isComplete) => {
+          Logger.info(
+            `onNext payload[data: ${payload.data}; metadata: ${payload.metadata}]|${isComplete}`
+          );
+          resolve(payload);
+        },
+        onComplete: () => {},
+        onExtension: () => {},
+      }
+    );
+  });
+}
+
+async function main() {
+  try {
+    // we expect this connection to fail because we aren't passing a valid token
+    const connector = makeConnector("");
+    const rsocket = await connector.connect();
+    await new Promise(function (resolve, reject) {
+      Logger.info("Rejecting once socket closes...");
+      rsocket.onClose((e) => {
+        reject(e);
+      });
+    });
+  } catch (e) {
+    Logger.error(`Expected error: ${e}`);
+  }
+
+  // NOTE: YOU SHOULD NEVER HARD CODE AN AUTH TOKEN IN A FILE IN THIS WAY. THIS IS PURELY FOR EXAMPLE PURPOSES.
+  // The SHA1 HASH of rsocket-js-2024-10
+  const exampleToken = "8a7d50f76ef86c75bd3563e55f8835515189dbff";
+
+  // we expect this connection to succeed because we pass a valid token
+  const connector = makeConnector(exampleToken);
+  const rsocket = await connector.connect();
+
+  // this request SHOULD pass
+  const echoResponse = await requestResponse(
+    rsocket,
+    makeMetadata(null, "EchoService.echo"),
+    "Hello World"
+  );
+  Logger.info(`EchoService.echo response: ${echoResponse.data.toString()}`);
+
+  // this request will reject (unknown route)
+  try {
+    await requestResponse(
+      rsocket,
+      makeMetadata(null, "UnknownService.unknown"),
+      "Hello World"
+    );
+  } catch (e) {
+    Logger.error(`Expected error: ${e}`);
+  }
+
+  // this request will reject (no routing data)
+  try {
+    await requestResponse(rsocket, makeMetadata(null), "Hello World");
+  } catch (e) {
+    Logger.error(`Expected error: ${e}`);
+  }
+
+  const whoAmiResponse = await requestResponse(
+    rsocket,
+    makeMetadata(exampleToken, "AuthService.whoAmI")
+  );
+  Logger.info(`AuthService.whoAmI response: ${whoAmiResponse.data.toString()}`);
+}
+
+main()
+  .then(() => exit())
+  .catch((error: Error) => {
+    Logger.error(error);
+    setTimeout(() => {
+      exit(1);
+    });
+  });

--- a/packages/rsocket-examples/src/composite-metadata/bearer-token-auth-setup-frame/server.ts
+++ b/packages/rsocket-examples/src/composite-metadata/bearer-token-auth-setup-frame/server.ts
@@ -21,22 +21,24 @@ import {
   OnNextSubscriber,
   OnTerminalSubscriber,
   Payload,
+  RSocket,
   RSocketError,
   RSocketServer,
-} from "rsocket-core";
-import { TcpServerTransport } from "rsocket-tcp-server";
+  SetupPayload,
+} from 'rsocket-core'
+import { TcpServerTransport } from 'rsocket-tcp-server'
 import {
   decodeAuthMetadata,
   decodeCompositeMetadata,
   decodeRoutes,
   WellKnownAuthType,
   WellKnownMimeType,
-} from "rsocket-composite-metadata";
-import { exit } from "process";
-import Logger from "../../shared/logger";
-import MESSAGE_RSOCKET_ROUTING = WellKnownMimeType.MESSAGE_RSOCKET_ROUTING;
-import MESSAGE_RSOCKET_AUTHENTICATION = WellKnownMimeType.MESSAGE_RSOCKET_AUTHENTICATION;
-import BEARER = WellKnownAuthType.BEARER;
+} from 'rsocket-composite-metadata'
+import { exit } from 'process'
+import Logger from '../../shared/logger'
+import MESSAGE_RSOCKET_ROUTING = WellKnownMimeType.MESSAGE_RSOCKET_ROUTING
+import MESSAGE_RSOCKET_AUTHENTICATION = WellKnownMimeType.MESSAGE_RSOCKET_AUTHENTICATION
+import BEARER = WellKnownAuthType.BEARER
 
 let serverCloseable: Closeable;
 
@@ -108,6 +110,14 @@ class EchoService {
 }
 
 class AuthService {
+  getUserContextForToken(mappedMetaData: Map<string, any>) {
+    const authContext = mappedMetaData.get(
+      MESSAGE_RSOCKET_AUTHENTICATION.toString()
+    );
+    const authToken = authContext.payload.toString();
+    return tokenToUserContext[authToken];
+  }
+
   handleWhoAmIRequestResponse(
     responderStream: OnTerminalSubscriber &
       OnNextSubscriber &
@@ -116,11 +126,7 @@ class AuthService {
     mappedMetaData: Map<string, any>
   ) {
     const timeout = setTimeout(() => {
-      const authContext = mappedMetaData.get(
-        MESSAGE_RSOCKET_AUTHENTICATION.toString()
-      );
-      const authToken = authContext.payload.toString();
-      const userContext = tokenToUserContext[authToken];
+      const userContext = this.getUserContextForToken(mappedMetaData);
       if (!userContext) {
         responderStream.onError(
           new RSocketError(
@@ -183,9 +189,23 @@ function makeServer() {
       },
     }),
     acceptor: {
-      accept: async () => {
+      accept: async (payload: SetupPayload, remotePeer: RSocket) => {
         const echoService = new EchoService();
         const authService = new AuthService();
+        const setupMetaData = mapMetaData(payload);
+        const authError = authMiddleware(setupMetaData);
+        if (authError) {
+          Logger.error(
+            `Auth error during setup. Peer will be closed. Caused by: ${authError}`
+          );
+          remotePeer.close(authError);
+          return {};
+        }
+        const userContext = authService.getUserContextForToken(setupMetaData);
+        Logger.info(`User connected... ${JSON.stringify(userContext)}`);
+        remotePeer.onClose(() => {
+          Logger.info(`User disconnected... ${JSON.stringify(userContext)}`);
+        });
         return {
           requestResponse: (
             payload: Payload,
@@ -201,13 +221,6 @@ function makeServer() {
               },
               onExtension() {},
             };
-
-            const authError = authMiddleware(mappedMetaData);
-            if (authError) {
-              Logger.error(`Auth error: ${authError}`);
-              responderStream.onError(authError);
-              return defaultSubscriber;
-            }
 
             const route = mappedMetaData.get(
               MESSAGE_RSOCKET_ROUTING.toString()

--- a/packages/rsocket-examples/src/composite-metadata/bearer-token-auth-setup-frame/server.ts
+++ b/packages/rsocket-examples/src/composite-metadata/bearer-token-auth-setup-frame/server.ts
@@ -25,20 +25,20 @@ import {
   RSocketError,
   RSocketServer,
   SetupPayload,
-} from 'rsocket-core'
-import { TcpServerTransport } from 'rsocket-tcp-server'
+} from "rsocket-core";
+import { TcpServerTransport } from "rsocket-tcp-server";
 import {
   decodeAuthMetadata,
   decodeCompositeMetadata,
   decodeRoutes,
   WellKnownAuthType,
   WellKnownMimeType,
-} from 'rsocket-composite-metadata'
-import { exit } from 'process'
-import Logger from '../../shared/logger'
-import MESSAGE_RSOCKET_ROUTING = WellKnownMimeType.MESSAGE_RSOCKET_ROUTING
-import MESSAGE_RSOCKET_AUTHENTICATION = WellKnownMimeType.MESSAGE_RSOCKET_AUTHENTICATION
-import BEARER = WellKnownAuthType.BEARER
+} from "rsocket-composite-metadata";
+import { exit } from "process";
+import Logger from "../../shared/logger";
+import MESSAGE_RSOCKET_ROUTING = WellKnownMimeType.MESSAGE_RSOCKET_ROUTING;
+import MESSAGE_RSOCKET_AUTHENTICATION = WellKnownMimeType.MESSAGE_RSOCKET_AUTHENTICATION;
+import BEARER = WellKnownAuthType.BEARER;
 
 let serverCloseable: Closeable;
 


### PR DESCRIPTION
Provides an example of passing authentication context via a bearer token with the setup frame via composite metadata.

### Motivation:

Demonstrate how to pass a bearer token or other metdata during connection/setup.

### Modifications:

Added new examples and npm scripts.

```
start-client-server-composite-metadata-auth-setup-frame-example-client
start-client-server-composite-metadata-auth-setup-frame-example-server
```

### Result:

Server logs:

```
[2024-10-15 02:38:17] Server bound...
[2024-10-15 02:38:23] Auth error during setup. Peer will be closed. Caused by: Error: Missing authentication context.
[2024-10-15 02:38:23] User connected... {"firstName":"bob","lastName":"builder"}
[2024-10-15 02:38:23] Handling EchoService.echo
[2024-10-15 02:38:24] Handling UnknownService.unknown
[2024-10-15 02:38:24] Handling AuthService.whoAmI
[2024-10-15 02:38:24] User disconnected... {"firstName":"bob","lastName":"builder"}
```

Client logs:

```
[2024-10-15 02:38:23] Rejecting once socket closes...
[2024-10-15 02:38:23] Expected error: Error: TcpDuplexConnection: Socket closed unexpectedly.
[2024-10-15 02:38:24] onNext payload[data: Echo: Hello World; metadata: null]|true
[2024-10-15 02:38:24] EchoService.echo response: Echo: Hello World
[2024-10-15 02:38:24] Expected error: Error: The encoded route was unknown by the server.
[2024-10-15 02:38:24] Expected error: Error: Composite metadata did not include routing information.
[2024-10-15 02:38:24] onNext payload[data: {"firstName":"bob","lastName":"builder"}; metadata: null]|true
[2024-10-15 02:38:24] AuthService.whoAmI response: {"firstName":"bob","lastName":"builder"}
```
