### PR TITLE
chore: move dependency in two examples to dev

### DIFF
--- a/packages/rsocket-examples/src/webpack/browser-bundle/package.json
+++ b/packages/rsocket-examples/src/webpack/browser-bundle/package.json
@@ -23,9 +23,7 @@
     "rsocket-websocket-client": "^1.0.0-alpha.3",
     "webpack": "^5",
     "webpack-cli": "^5",
-    "webpack-dev-server": "^5"
-  },
-  "dependencies": {
-    "html-webpack-plugin": "^5.5.3"
+    "webpack-dev-server": "^5",
+    "html-webpack-plugin": "^5"
   }
 }

--- a/packages/rsocket-examples/src/webpack/browser-bundle/yarn.lock
+++ b/packages/rsocket-examples/src/webpack/browser-bundle/yarn.lock
@@ -1179,10 +1179,10 @@ html-minifier-terser@^6.0.2:
     relateurl "^0.2.7"
     terser "^5.10.0"
 
-html-webpack-plugin@^5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.5.3.tgz#72270f4a78e222b5825b296e5e3e1328ad525a3e"
-  integrity sha512-6YrDKTuqaP/TquFH7h4srYWsZx+x6k6+FbsTm0ziCwGHDP78Unr1r9F/H4+sGmMbX08GQcJ+K64x55b+7VM/jg==
+html-webpack-plugin@^5:
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.6.3.tgz#a31145f0fee4184d53a794f9513147df1e653685"
+  integrity sha512-QSf1yjtSAsmf7rYBV7XX86uua4W/vkhIt0xNXKbsi2foEeW7vjJQz4bhnpL3xH+l1ryl1680uNv968Z+X6jSYg==
   dependencies:
     "@types/html-minifier-terser" "^6.0.0"
     html-minifier-terser "^6.0.2"

--- a/packages/rsocket-examples/src/webpack/simple/client/package.json
+++ b/packages/rsocket-examples/src/webpack/simple/client/package.json
@@ -23,9 +23,7 @@
     "rsocket-websocket-client": "^1.0.0-alpha.3",
     "webpack": "^5.74.0",
     "webpack-cli": "^5",
-    "webpack-dev-server": "^5"
-  },
-  "dependencies": {
-    "html-webpack-plugin": "^5.5.0"
+    "webpack-dev-server": "^5",
+    "html-webpack-plugin": "^5"
   }
 }

--- a/packages/rsocket-examples/src/webpack/simple/client/yarn.lock
+++ b/packages/rsocket-examples/src/webpack/simple/client/yarn.lock
@@ -1142,7 +1142,7 @@ html-minifier-terser@^6.0.2:
     relateurl "^0.2.7"
     terser "^5.10.0"
 
-html-webpack-plugin@^5.5.0:
+html-webpack-plugin@^5:
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.6.3.tgz#a31145f0fee4184d53a794f9513147df1e653685"
   integrity sha512-QSf1yjtSAsmf7rYBV7XX86uua4W/vkhIt0xNXKbsi2foEeW7vjJQz4bhnpL3xH+l1ryl1680uNv968Z+X6jSYg==


### PR DESCRIPTION
Moved dependency to dev-dependency.

### Motivation:

Dependabot to ignore low-risk alerts in these dependencies.

### Modifications:

- moved `html-webpack-plugin` to devDependencies
- moved `webpack-dev-server` to devDependencies

### Result:

n/a