### PR TITLE
fix: Replace Date.now() with performance.now()

### DIFF
--- a/packages/rsocket-core/src/RSocketSupport.ts
+++ b/packages/rsocket-core/src/RSocketSupport.ts
@@ -200,7 +200,7 @@ export class LeaseHandler implements LeaseManager {
   ) {}
 
   handle(frame: LeaseFrame): void {
-    this.expirationTime = frame.ttl + Date.now();
+    this.expirationTime = frame.ttl + performance.now();
     this.availableLease = frame.requestCount;
 
     while (this.availableLease > 0 && this.pendingRequests.length > 0) {
@@ -213,7 +213,7 @@ export class LeaseHandler implements LeaseManager {
 
   requestLease(handler: StreamFrameHandler & StreamLifecycleHandler): void {
     const availableLease = this.availableLease;
-    if (availableLease > 0 && Date.now() < this.expirationTime) {
+    if (availableLease > 0 && performance.now() < this.expirationTime) {
       this.availableLease = availableLease - 1;
       this.multiplexer.createRequestStream(handler);
       return;
@@ -414,7 +414,7 @@ export class KeepAliveHandler implements FrameHandler {
   }
 
   handle(frame: KeepAliveFrame): void {
-    this.keepAliveLastReceivedMillis = Date.now();
+    this.keepAliveLastReceivedMillis = performance.now();
     if (Flags.hasRespond(frame.flags)) {
       this.outbound.send({
         type: FrameTypes.KEEPALIVE,
@@ -431,7 +431,7 @@ export class KeepAliveHandler implements FrameHandler {
       return;
     }
 
-    this.keepAliveLastReceivedMillis = Date.now();
+    this.keepAliveLastReceivedMillis = performance.now();
     this.state = KeepAliveHandlerStates.Running;
     this.activeTimeout = setTimeout(
       this.timeoutCheck.bind(this),
@@ -454,7 +454,7 @@ export class KeepAliveHandler implements FrameHandler {
   }
 
   private timeoutCheck() {
-    const now = Date.now();
+    const now = performance.now();
     const noKeepAliveDuration = now - this.keepAliveLastReceivedMillis;
     if (noKeepAliveDuration >= this.keepAliveTimeoutDuration) {
       this.connection.close(


### PR DESCRIPTION
When using WebsocketClientTransport I've noticed if a users local clock gets adjusted, a connection timeout is triggered:

> No keep-alive acks for 30000 millis
> WebsocketDuplexConnection: Socket closed unexpectedly

This is caused by keeping track of timeout with `Date.now()` which doesn't account for clock skew.

See https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#performance.now_vs._date.now