### PR TITLE
fix Constructor doesn't store fragmentation

### DIFF
--- a/packages/rsocket-core/src/RSocketServer.ts
+++ b/packages/rsocket-core/src/RSocketServer.ts
@@ -69,6 +69,7 @@ export class RSocketServer {
     this.acceptor = config.acceptor;
     this.transport = config.transport;
     this.lease = config.lease;
+    this.fragmentation = config.fragmentation;
     this.serverSideKeepAlive = config.serverSideKeepAlive;
     this.sessionStore = config.resume ? {} : undefined;
     this.sessionTimeout = config.resume?.sessionTimeout ?? undefined;
@@ -154,7 +155,7 @@ export class RSocketServer {
               );
               const streamsHandler = new DefaultStreamRequestHandler(
                 responder,
-                0
+                this.fragmentation?.maxOutboundFragmentSize ?? 0,
               );
 
               connection.onClose((e) => {


### PR DESCRIPTION
Bug
RSocketServer accepts a fragmentation.maxOutboundFragmentSize config, but it only applies to
the requester side (server-initiated requests). The responder side (server responses to client
requests) always uses fragmentSize=0, meaning responses are never fragmented.

This causes a crash when the server tries to send a response larger than 16MB (the RSocket frame
length field is 24-bit, max 16,777,215 bytes), because writeUInt24BE overflows:

RangeError: The value of "value" is out of range. It must be >= 0 and <= 255.
    at writeUInt24BE (rsocket-core/src/Codecs.ts:80)
    at serializeFrameWithLength (rsocket-core/src/Codecs.ts:161)
Root Cause
Two issues in packages/rsocket-core/src/RSocketServer.ts:

Constructor doesn't store fragmentation: The fragmentation field from ServerConfig is
never assigned to this, so this.fragmentation is always undefined.

DefaultStreamRequestHandler hardcodes fragmentSize=0: Even if this.fragmentation were
stored, the stream handler is created with fragmentSize=0 instead of using the configured value.

Signed-off-by: Niteesh <niteesh3@gmail.com>